### PR TITLE
Minimal reproduction for #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ postcard = { version = "1.0", features = ["alloc"] }
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = "0.3.1"
 serde = { version = "1.0.159", features = [ "derive" ] }
+musli = "*"
 
 [features]
 derive = [ "bitcode_derive" ]

--- a/examples/decode_conflict.rs
+++ b/examples/decode_conflict.rs
@@ -1,0 +1,8 @@
+use musli::Decode;
+
+#[derive(bitcode::Decode)]
+struct Struct {
+    field: u64,
+}
+
+fn main() {}

--- a/examples/encode_conflict.rs
+++ b/examples/encode_conflict.rs
@@ -1,0 +1,8 @@
+use musli::Encode;
+
+#[derive(bitcode::Encode)]
+struct Struct {
+    field: u64,
+}
+
+fn main() {}


### PR DESCRIPTION
This is just a minimal repro for #2 and is not for merging, I recommend you work with [`cargo expand`](https://crates.io/crates/cargo-expand) (e.g. `cargo expand --example decode_conflict`) to get a better idea of what's going on.

<summary>

Output of `cargo build --example decode_conflict`

<details>

```
error[E0034]: multiple applicable items in scope
 --> examples\decode_conflict.rs:3:10
  |
3 | #[derive(bitcode::Decode)]
  |          ^^^^^^^^^^^^^^^ multiple `decode` found
  |
  = note: candidate #1 is defined in an impl of the trait `bitcode::Decode` for the type `u64`
  = note: candidate #2 is defined in an impl of the trait `musli::Decode` for the type `u64`
  = note: this error originates in the macro `dec` which comes from the expansion of the derive macro `bitcode::Decode` (in Nightly builds, run with -Z macro-backtrace for more info)
help: disambiguate the associated function for candidate #1
 --> D:\Repo\bitcode\src\code.rs:270:21
  |
27|                     <u64 as bitcode::Decode>::decode($encoding, &mut buf.inner)?
  |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the associated function for candidate #2
 --> D:\Repo\bitcode\src\code.rs:270:21
  |
27|                     <u64 as musli::Decode>::decode($encoding, &mut buf.inner)?
  |                     ~~~~~~~~~~~~~~~~~~~~~~~~

error[E0034]: multiple applicable items in scope
 --> examples\decode_conflict.rs:3:10
  |
3 | #[derive(bitcode::Decode)]
  |          ^^^^^^^^^^^^^^^ multiple `decode` found
  |
  = note: candidate #1 is defined in an impl of the trait `bitcode::Decode` for the type `u64`
  = note: candidate #2 is defined in an impl of the trait `musli::Decode` for the type `u64`
  = note: this error originates in the macro `dec` which comes from the expansion of the derive macro `bitcode::Decode` (in Nightly builds, run with -Z macro-backtrace for more info)
help: disambiguate the associated function for candidate #1
 --> D:\Repo\bitcode\src\code.rs:274:25
  |
27|                         <u64 as bitcode::Decode>::decode($encoding, &mut buf.inner)?
  |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the associated function for candidate #2
 --> D:\Repo\bitcode\src\code.rs:274:25
  |
27|                         <u64 as musli::Decode>::decode($encoding, &mut buf.inner)?
  |                         ~~~~~~~~~~~~~~~~~~~~~~~~

error[E0034]: multiple applicable items in scope
 --> examples\decode_conflict.rs:3:10
  |
3 | #[derive(bitcode::Decode)]
  |          ^^^^^^^^^^^^^^^ multiple `decode` found
  |
  = note: candidate #1 is defined in an impl of the trait `bitcode::Decode` for the type `u64`
  = note: candidate #2 is defined in an impl of the trait `musli::Decode` for the type `u64`
  = note: this error originates in the macro `dec` which comes from the expansion of the derive macro `bitcode::Decode` (in Nightly builds, run with -Z macro-backtrace for more info)
help: disambiguate the associated function for candidate #1
 --> D:\Repo\bitcode\src\code.rs:277:25
  |
27|                         <u64 as bitcode::Decode>::decode($encoding, buf.reader)?
  |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
help: disambiguate the associated function for candidate #2
 --> D:\Repo\bitcode\src\code.rs:277:25
  |
27|                         <u64 as musli::Decode>::decode($encoding, buf.reader)?
  |                         ~~~~~~~~~~~~~~~~~~~~~~~~

warning: unused import: `musli::Decode`
 --> examples\decode_conflict.rs:1:5
  |
1 | use musli::Decode;
  |     ^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0034`.
warning: `bitcode` (example "decode_conflict") generated 1 warning
error: could not compile `bitcode` due to 3 previous errors; 1 warning emitted
```
</details>
</summary>