### PR TITLE
silence `verbose_bit_mask` lint in bitcode_derive

### DIFF
--- a/bitcode_derive/src/attribute.rs
+++ b/bitcode_derive/src/attribute.rs
@@ -432,6 +432,7 @@ impl VariantEncoding {
                 let variants = variants?;
 
                 quote! {
+                    #[allow(clippy::verbose_bit_mask)]
                     Ok(match dec_variant_peek!() {
                         #variants,
                     })


### PR DESCRIPTION
Suppresses the other lint in #7, `clippy::verbose_bit_mask`