### PR TITLE
Add #![no_std] compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
         run: cargo test
       - name: Test (all-features)
         run: cargo test --all-features
+      - name: Test (no_std)
+        run: cargo test --no-default-features --features derive,serde
       - name: Install i686 and GCC multilib
         run: rustup target add i686-unknown-linux-gnu && sudo apt update && sudo apt install -y gcc-multilib
       - name: Test (32-bit all-features)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Test (all-features)
         run: cargo test --all-features
       - name: Test (no_std)
-        run: cargo test --no-default-features --features derive,serde
+        run: cargo test --no-default-features --features derive,serde,glam,arrayvec
       - name: Install i686 and GCC multilib
         run: rustup target add i686-unknown-linux-gnu && sudo apt update && sudo apt install -y gcc-multilib
       - name: Test (32-bit all-features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ std = [ "serde?/std", "glam?/std", "arrayvec?/std" ]
 default = [ "derive", "std" ]
 
 [package.metadata.docs.rs]
-features = [ "derive", "serde" ]
+features = [ "derive", "serde", "std" ]
 
 # TODO halfs speed of benches_borrowed::bench_bitcode_decode
 #[profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ zstd = "0.13.0"
 
 [features]
 derive = [ "bitcode_derive" ]
-default = [ "derive" ]
+std = []
+default = [ "derive", "std" ]
 
 [package.metadata.docs.rs]
 features = [ "derive", "serde" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ arrayvec = { version = "0.7", default-features = false, optional = true }
 bitcode_derive = { version = "0.6.0", path = "./bitcode_derive", optional = true }
 bytemuck = { version = "1.14", features = [ "min_const_generics", "must_cast" ] }
 glam = { version = ">=0.21", default-features = false, features = [ "std" ], optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, features = [ "alloc" ], optional = true }
 
 [dev-dependencies]
 arrayvec = { version = "0.7", features = [ "serde" ] }
@@ -37,7 +37,7 @@ zstd = "0.13.0"
 
 [features]
 derive = [ "bitcode_derive" ]
-std = []
+std = [ "serde?/std" ]
 default = [ "derive", "std" ]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["fuzz/"]
 arrayvec = { version = "0.7", default-features = false, optional = true }
 bitcode_derive = { version = "0.6.0", path = "./bitcode_derive", optional = true }
 bytemuck = { version = "1.14", features = [ "min_const_generics", "must_cast" ] }
-glam = { version = ">=0.21", default-features = false, features = [ "std" ], optional = true }
+glam = { version = ">=0.21", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = [ "alloc" ], optional = true }
 
 [dev-dependencies]
@@ -37,7 +37,7 @@ zstd = "0.13.0"
 
 [features]
 derive = [ "bitcode_derive" ]
-std = [ "serde?/std" ]
+std = [ "serde?/std", "glam?/std", "arrayvec?/std" ]
 default = [ "derive", "std" ]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ If you have multiple values of the same type:
 - Validation is performed up front on typed vectors before deserialization
 - Code is designed to be auto-vectorized by LLVM
 
+## `#![no_std]`
+All `std`-only functionality is gated behind the (default) `"std"` feature.
+
+`alloc` is required.
+
 ## License
 Licensed under either of
 * Apache License, Version 2.0

--- a/bitcode_derive/src/attribute.rs
+++ b/bitcode_derive/src/attribute.rs
@@ -1,7 +1,7 @@
 use crate::{err, error};
 use alloc::format;
-use proc_macro2::TokenStream;
 use core::str::FromStr;
+use proc_macro2::TokenStream;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{parse2, Attribute, Expr, ExprLit, Lit, Meta, Path, Result, Token, Type};

--- a/bitcode_derive/src/attribute.rs
+++ b/bitcode_derive/src/attribute.rs
@@ -1,6 +1,7 @@
 use crate::{err, error};
+use alloc::format;
 use proc_macro2::TokenStream;
-use std::str::FromStr;
+use core::str::FromStr;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{parse2, Attribute, Expr, ExprLit, Lit, Meta, Path, Result, Token, Type};

--- a/bitcode_derive/src/attribute.rs
+++ b/bitcode_derive/src/attribute.rs
@@ -1,7 +1,6 @@
 use crate::{err, error};
-use alloc::format;
-use core::str::FromStr;
 use proc_macro2::TokenStream;
+use std::str::FromStr;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{parse2, Attribute, Expr, ExprLit, Lit, Meta, Path, Result, Token, Type};

--- a/bitcode_derive/src/decode.rs
+++ b/bitcode_derive/src/decode.rs
@@ -1,6 +1,5 @@
 use crate::private;
 use crate::shared::{remove_lifetimes, replace_lifetimes, variant_index};
-use alloc::format;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{

--- a/bitcode_derive/src/decode.rs
+++ b/bitcode_derive/src/decode.rs
@@ -1,5 +1,6 @@
 use crate::private;
 use crate::shared::{remove_lifetimes, replace_lifetimes, variant_index};
+use alloc::format;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
@@ -163,7 +164,7 @@ impl crate::shared::Item for Item {
                 if never {
                     return quote! {
                         // Safety: View::populate will error on length != 0 so decode won't be called.
-                        unsafe { std::hint::unreachable_unchecked() }
+                        unsafe { core::hint::unreachable_unchecked() }
                     };
                 }
                 let pattern = |i: usize| {
@@ -195,7 +196,7 @@ impl crate::shared::Item for Item {
                             match self.variants.decode() {
                                 #variants
                                 // Safety: VariantDecoder<N, _>::decode outputs numbers less than N.
-                                _ => unsafe { std::hint::unreachable_unchecked() }
+                                _ => unsafe { core::hint::unreachable_unchecked() }
                             }
                         }
                     })
@@ -273,7 +274,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
 
         let [mut type_body, mut default_body, populate_body, decode_in_place_body] = output;
         if type_body.is_empty() {
-            type_body = quote! { __spooky: std::marker::PhantomData<&#de ()>, };
+            type_body = quote! { __spooky: core::marker::PhantomData<&#de ()>, };
         }
         if default_body.is_empty() {
             default_body = quote! { __spooky: Default::default(), };
@@ -295,7 +296,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
                 }
 
                 // Avoids bounding #impl_generics: Default.
-                impl #decoder_impl_generics std::default::Default for #decoder_ty #decoder_where_clause {
+                impl #decoder_impl_generics core::default::Default for #decoder_ty #decoder_where_clause {
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -312,7 +313,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
 
                 impl #impl_generics #private::Decoder<#de, #input_ty> for #decoder_ty #where_clause {
                     #[cfg_attr(not(debug_assertions), inline(always))]
-                    fn decode_in_place(&mut self, out: &mut std::mem::MaybeUninit<#input_ty>) {
+                    fn decode_in_place(&mut self, out: &mut core::mem::MaybeUninit<#input_ty>) {
                         #decode_in_place_body
                     }
                 }

--- a/bitcode_derive/src/encode.rs
+++ b/bitcode_derive/src/encode.rs
@@ -1,5 +1,6 @@
 use crate::private;
 use crate::shared::{remove_lifetimes, replace_lifetimes, variant_index};
+use alloc::format;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{parse_quote, Generics, Path, Type};
@@ -52,7 +53,7 @@ impl crate::shared::Item for Item {
                     // does not exist. Instead we replace this with <T<'static> as Encode>::Encoder and transmute it to
                     // T<'a>. No encoder actually encodes T<'static> any differently from T<'a> so this is sound.
                     quote! {
-                        unsafe { std::mem::transmute::<&#underscore_type, &#static_type>(#field_name) }
+                        unsafe { core::mem::transmute::<&#underscore_type, &#static_type>(#field_name) }
                     }
                 } else {
                     quote! { #field_name }
@@ -157,7 +158,7 @@ impl crate::shared::Item for Item {
                             .then(|| {
                                 let reserve = inner(Self::Reserve, i);
                                 quote! {
-                                    let __additional = std::num::NonZeroUsize::MIN;
+                                    let __additional = core::num::NonZeroUsize::MIN;
                                     #reserve
                                 }
                             })
@@ -262,7 +263,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
                 }
 
                 // Avoids bounding #impl_generics: Default.
-                impl #encoder_impl_generics std::default::Default for #encoder_ty #encoder_where_clause {
+                impl #encoder_impl_generics core::default::Default for #encoder_ty #encoder_where_clause {
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -292,7 +293,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
                         #collect_into_body
                     }
 
-                    fn reserve(&mut self, __additional: std::num::NonZeroUsize) {
+                    fn reserve(&mut self, __additional: core::num::NonZeroUsize) {
                         #reserve_body
                     }
                 }

--- a/bitcode_derive/src/encode.rs
+++ b/bitcode_derive/src/encode.rs
@@ -1,6 +1,5 @@
 use crate::private;
 use crate::shared::{remove_lifetimes, replace_lifetimes, variant_index};
-use alloc::format;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{parse_quote, Generics, Path, Type};

--- a/bitcode_derive/src/lib.rs
+++ b/bitcode_derive/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use crate::decode::Decode;
 use crate::encode::Encode;
 use crate::shared::Derive;

--- a/bitcode_derive/src/lib.rs
+++ b/bitcode_derive/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use crate::decode::Decode;
 use crate::encode::Encode;
 use crate::shared::Derive;

--- a/bitcode_derive/src/shared.rs
+++ b/bitcode_derive/src/shared.rs
@@ -1,7 +1,6 @@
 use crate::attribute::BitcodeAttrs;
 use crate::bound::FieldBounds;
 use crate::err;
-use alloc::format;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::visit_mut::VisitMut;
@@ -184,12 +183,12 @@ fn field_name(i: usize, field: &Field, real: bool) -> TokenStream {
 }
 
 pub fn remove_lifetimes(generics: &mut Generics) {
-    generics.params = core::mem::take(&mut generics.params)
+    generics.params = std::mem::take(&mut generics.params)
         .into_iter()
         .filter(|param| !matches!(param, GenericParam::Lifetime(_)))
         .collect();
     if let Some(where_clause) = &mut generics.where_clause {
-        where_clause.predicates = core::mem::take(&mut where_clause.predicates)
+        where_clause.predicates = std::mem::take(&mut where_clause.predicates)
             .into_iter()
             .filter(|predicate| !matches!(predicate, WherePredicate::Lifetime(_)))
             .collect()

--- a/bitcode_derive/src/shared.rs
+++ b/bitcode_derive/src/shared.rs
@@ -1,6 +1,7 @@
 use crate::attribute::BitcodeAttrs;
 use crate::bound::FieldBounds;
 use crate::err;
+use alloc::format;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::visit_mut::VisitMut;
@@ -183,12 +184,12 @@ fn field_name(i: usize, field: &Field, real: bool) -> TokenStream {
 }
 
 pub fn remove_lifetimes(generics: &mut Generics) {
-    generics.params = std::mem::take(&mut generics.params)
+    generics.params = core::mem::take(&mut generics.params)
         .into_iter()
         .filter(|param| !matches!(param, GenericParam::Lifetime(_)))
         .collect();
     if let Some(where_clause) = &mut generics.where_clause {
-        where_clause.predicates = std::mem::take(&mut where_clause.predicates)
+        where_clause.predicates = core::mem::take(&mut where_clause.predicates)
             .into_iter()
             .filter(|predicate| !matches!(predicate, WherePredicate::Lifetime(_)))
             .collect()

--- a/src/benches.rs
+++ b/src/benches.rs
@@ -3,6 +3,8 @@ use rand_chacha::ChaCha20Rng;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use test::black_box;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[cfg(feature = "arrayvec")]
 use arrayvec::{ArrayString, ArrayVec};

--- a/src/benches.rs
+++ b/src/benches.rs
@@ -168,6 +168,7 @@ bench!(serialize, deserialize, bitcode);
 #[cfg(feature = "derive")]
 bench!(encode, decode, bitcode);
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,6 +249,7 @@ mod tests {
     }
 }
 
+#[cfg(feature = "std")]
 mod compression {
     use flate2::read::DeflateDecoder;
     use flate2::write::DeflateEncoder;

--- a/src/benches.rs
+++ b/src/benches.rs
@@ -1,10 +1,10 @@
+use alloc::string::String;
+use alloc::vec::Vec;
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use test::black_box;
-use alloc::string::String;
-use alloc::vec::Vec;
 
 #[cfg(feature = "arrayvec")]
 use arrayvec::{ArrayString, ArrayVec};

--- a/src/benches_borrowed.rs
+++ b/src/benches_borrowed.rs
@@ -1,7 +1,7 @@
 use crate::benches::{bench_data, Data, DataEnum, MAX_DATA_ENUMS};
-use serde::{Deserialize, Serialize};
 use alloc::vec::Vec;
 use core::array;
+use serde::{Deserialize, Serialize};
 use test::{black_box, Bencher};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/benches_borrowed.rs
+++ b/src/benches_borrowed.rs
@@ -1,6 +1,7 @@
 use crate::benches::{bench_data, Data, DataEnum, MAX_DATA_ENUMS};
 use serde::{Deserialize, Serialize};
-use std::array;
+use alloc::vec::Vec;
+use core::array;
 use test::{black_box, Bencher};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -1,7 +1,8 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::fast::{CowSlice, NextUnchecked, PushUnchecked, SliceImpl, Unaligned, VecImpl};
 use crate::pack::{pack_bools, unpack_bools};
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct BoolEncoder(VecImpl<bool>);
@@ -44,7 +45,7 @@ impl<'a> Decoder<'a, bool> for BoolDecoder<'a> {
     fn as_primitive(&mut self) -> Option<&mut SliceImpl<Unaligned<bool>>> {
         // Safety: `Unaligned<bool>` is equivalent to bool since it's a `#[repr(C, packed)]` wrapper
         // around bool and both have size/align of 1.
-        unsafe { Some(std::mem::transmute(self.0.mut_slice())) }
+        unsafe { Some(core::mem::transmute(self.0.mut_slice())) }
     }
 
     #[inline(always)]
@@ -55,6 +56,8 @@ impl<'a> Decoder<'a, bool> for BoolDecoder<'a> {
 
 #[cfg(test)]
 mod test {
+    use alloc::vec::Vec;
+
     fn bench_data() -> Vec<bool> {
         (0..=1000).map(|_| false).collect()
     }
@@ -63,6 +66,8 @@ mod test {
 
 #[cfg(test)]
 mod test2 {
+    use alloc::vec::Vec;
+
     fn bench_data() -> Vec<Vec<bool>> {
         crate::random_data::<u8>(125)
             .into_iter()

--- a/src/coder.rs
+++ b/src/coder.rs
@@ -1,8 +1,9 @@
 use crate::fast::{SliceImpl, Unaligned, VecImpl};
-use std::mem::MaybeUninit;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
 
-pub type Result<T> = std::result::Result<T, crate::Error>;
+pub type Result<T> = core::result::Result<T, crate::Error>;
 
 /// TODO pick different name because it aliases with [`crate::buffer::Buffer`].
 pub trait Buffer {
@@ -101,8 +102,8 @@ pub trait Decoder<'a, T>: View<'a> + Default + Send + Sync {
 macro_rules! __private_uninit_field {
     ($uninit:ident.$field:tt:$field_ty:ty) => {
         unsafe {
-            &mut *(std::ptr::addr_of_mut!((*$uninit.as_mut_ptr()).$field)
-                as *mut std::mem::MaybeUninit<$field_ty>)
+            &mut *(core::ptr::addr_of_mut!((*$uninit.as_mut_ptr()).$field)
+                as *mut core::mem::MaybeUninit<$field_ty>)
         }
     };
 }

--- a/src/derive/array.rs
+++ b/src/derive/array.rs
@@ -2,8 +2,9 @@ use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::consume::mul_length;
 use crate::derive::{Decode, Encode};
 use crate::fast::{FastSlice, FastVec, Unaligned};
-use std::mem::MaybeUninit;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
 
 pub struct ArrayEncoder<T: Encode, const N: usize>(T::Encoder);
 
@@ -28,7 +29,7 @@ impl<T: Encode, const N: usize> Encoder<[T; N]> for ArrayEncoder<T, N> {
             // NOTE: If panics occurs during ArrayEncoder::encode and Buffer is reused, this
             // invariant can be violated. Luckily primitive encoders never panic.
             // TODO std::mem::take Buffer while encoding to avoid corrupted buffers.
-            unsafe { std::mem::transmute(v) }
+            unsafe { core::mem::transmute(v) }
         })
     }
 
@@ -79,7 +80,7 @@ impl<'a, T: Decode<'a>, const N: usize> Decoder<'a, [T; N]> for ArrayDecoder<'a,
         self.0.as_primitive().map(|s| {
             // Safety: FastSlice doesn't have a length unlike slice, so casting to FastSlice<[T; N]>
             // is safe. N == 0 case is also safe for the same reason.
-            unsafe { std::mem::transmute(s) }
+            unsafe { core::mem::transmute(s) }
         })
     }
 
@@ -99,7 +100,8 @@ mod tests {
     use crate::error::err;
     use crate::length::LengthEncoder;
     use crate::{decode, encode};
-    use std::num::NonZeroUsize;
+    use alloc::vec::Vec;
+    use core::num::NonZeroUsize;
 
     #[test]
     fn test_empty_array() {

--- a/src/derive/duration.rs
+++ b/src/derive/duration.rs
@@ -1,9 +1,9 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::{Decode, Encode};
+use alloc::vec::Vec;
 use bytemuck::CheckedBitPattern;
 use core::num::NonZeroUsize;
 use core::time::Duration;
-use alloc::vec::Vec;
 
 #[derive(Default)]
 pub struct DurationEncoder {
@@ -87,8 +87,8 @@ mod tests {
         assert!(crate::decode::<Duration>(&crate::encode(&(u64::MAX, 1_000_000_000))).is_err());
     }
 
-    use core::time::Duration;
     use alloc::vec::Vec;
+    use core::time::Duration;
     fn bench_data() -> Vec<Duration> {
         crate::random_data(1000)
             .into_iter()

--- a/src/derive/duration.rs
+++ b/src/derive/duration.rs
@@ -1,8 +1,9 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::{Decode, Encode};
 use bytemuck::CheckedBitPattern;
-use std::num::NonZeroUsize;
-use std::time::Duration;
+use core::num::NonZeroUsize;
+use core::time::Duration;
+use alloc::vec::Vec;
 
 #[derive(Default)]
 pub struct DurationEncoder {
@@ -68,7 +69,7 @@ impl<'a> Decoder<'a, Duration> for DurationDecoder<'a> {
         // Safety: impl CheckedBitPattern for Nanoseconds guarantees this.
         unsafe {
             if !Nanoseconds::is_valid_bit_pattern(&subsec_nanos) {
-                std::hint::unreachable_unchecked();
+                core::hint::unreachable_unchecked();
             }
         }
         Duration::new(secs, subsec_nanos)
@@ -86,7 +87,8 @@ mod tests {
         assert!(crate::decode::<Duration>(&crate::encode(&(u64::MAX, 1_000_000_000))).is_err());
     }
 
-    use std::time::Duration;
+    use core::time::Duration;
+    use alloc::vec::Vec;
     fn bench_data() -> Vec<Duration> {
         crate::random_data(1000)
             .into_iter()

--- a/src/derive/empty.rs
+++ b/src/derive/empty.rs
@@ -1,6 +1,7 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
-use std::marker::PhantomData;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct EmptyCoder;
@@ -28,7 +29,9 @@ impl<'a, T> Decoder<'a, PhantomData<T>> for EmptyCoder {
 
 #[cfg(test)]
 mod tests {
-    use std::marker::PhantomData;
+    use alloc::vec::Vec;
+    use core::marker::PhantomData;
+
     fn bench_data() -> Vec<PhantomData<()>> {
         vec![PhantomData; 100]
     }

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -19,9 +19,9 @@ use core::mem::MaybeUninit;
 use core::num::*;
 
 #[cfg(feature = "std")]
-use std::collections::{HashMap, HashSet};
+use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "std")]
-use core::hash::{Hash, BuildHasher};
+use std::collections::{HashMap, HashSet};
 
 macro_rules! impl_both {
     ($t:ty, $encoder:ident, $decoder:ident) => {

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -11,6 +11,12 @@ use crate::derive::{Decode, Encode};
 use crate::f32::{F32Decoder, F32Encoder};
 use crate::int::{CheckedIntDecoder, IntDecoder, IntEncoder};
 use crate::str::{StrDecoder, StrEncoder};
+use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::num::*;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
@@ -105,9 +111,9 @@ macro_rules! impl_smart_ptr {
         }
     }
 }
-impl_smart_ptr!(::std::boxed::Box);
-impl_smart_ptr!(::std::rc::Rc);
-impl_smart_ptr!(::std::sync::Arc);
+impl_smart_ptr!(::alloc::boxed::Box);
+impl_smart_ptr!(::alloc::rc::Rc);
+impl_smart_ptr!(::alloc::sync::Arc);
 
 impl<T: Encode, const N: usize> Encode for [T; N] {
     type Encoder = ArrayEncoder<T, N>;
@@ -166,10 +172,10 @@ impl<'a, K: Decode<'a> + Eq + Hash, V: Decode<'a>, S: BuildHasher + Default> Dec
     type Decoder = MapDecoder<'a, K, V>;
 }
 
-impl<T: Encode, E: Encode> Encode for std::result::Result<T, E> {
+impl<T: Encode, E: Encode> Encode for core::result::Result<T, E> {
     type Encoder = ResultEncoder<T, E>;
 }
-impl<'a, T: Decode<'a>, E: Decode<'a>> Decode<'a> for std::result::Result<T, E> {
+impl<'a, T: Decode<'a>, E: Decode<'a>> Decode<'a> for core::result::Result<T, E> {
     type Decoder = ResultDecoder<'a, T, E>;
 }
 impl<T> Encode for PhantomData<T> {
@@ -236,7 +242,7 @@ macro_rules! impl_tuples {
 
                 pub struct TupleDecoder<'a, $($name: Decode<'a>,)*>(
                     $($name::Decoder,)*
-                    std::marker::PhantomData<&'a ()>,
+                    core::marker::PhantomData<&'a ()>,
                 );
 
                 impl<'a, $($name: Decode<'a>,)*> Default for TupleDecoder<'a, $($name,)*> {
@@ -292,6 +298,9 @@ impl_tuples! {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
     type Tuple = (u64, u32, u8, i32, u8, u16, i8, (u8, u8, u8, u8), i8);
     fn bench_data() -> Vec<(Tuple, Option<String>)> {
         crate::random_data(1000)

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -17,11 +17,11 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::num::*;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
-use std::hash::{BuildHasher, Hash};
-use std::marker::PhantomData;
-use std::mem::MaybeUninit;
-use std::num::*;
+
+#[cfg(feature = "std")]
+use std::collections::{HashMap, HashSet};
+#[cfg(feature = "std")]
+use core::hash::{Hash, BuildHasher};
 
 macro_rules! impl_both {
     ($t:ty, $encoder:ident, $decoder:ident) => {
@@ -150,9 +150,11 @@ impl<T: Encode> Encode for BTreeSet<T> {
 impl<'a, T: Decode<'a> + Ord> Decode<'a> for BTreeSet<T> {
     type Decoder = VecDecoder<'a, T>;
 }
+#[cfg(feature = "std")]
 impl<T: Encode, S> Encode for HashSet<T, S> {
     type Encoder = VecEncoder<T>;
 }
+#[cfg(feature = "std")]
 impl<'a, T: Decode<'a> + Eq + Hash, S: BuildHasher + Default> Decode<'a> for HashSet<T, S> {
     type Decoder = VecDecoder<'a, T>;
 }
@@ -163,9 +165,11 @@ impl<K: Encode, V: Encode> Encode for BTreeMap<K, V> {
 impl<'a, K: Decode<'a> + Ord, V: Decode<'a>> Decode<'a> for BTreeMap<K, V> {
     type Decoder = MapDecoder<'a, K, V>;
 }
+#[cfg(feature = "std")]
 impl<K: Encode, V: Encode, S> Encode for HashMap<K, V, S> {
     type Encoder = MapEncoder<K, V>;
 }
+#[cfg(feature = "std")]
 impl<'a, K: Decode<'a> + Eq + Hash, V: Decode<'a>, S: BuildHasher + Default> Decode<'a>
     for HashMap<K, V, S>
 {

--- a/src/derive/map.rs
+++ b/src/derive/map.rs
@@ -117,14 +117,12 @@ impl<'a, K: Decode<'a> + Eq + Hash, V: Decode<'a>, S: BuildHasher + Default>
 #[cfg(test)]
 mod test {
     use alloc::collections::BTreeMap;
-    #[cfg(feature = "std")]
-    use std::collections::HashMap;
 
     fn bench_data<T: FromIterator<(u8, u8)>>() -> T {
         (0..=255).map(|k| (k, 0)).collect()
     }
-    #[cfg(feature = "std")]
-    crate::bench_encode_decode!(btree_map: BTreeMap<_, _>, hash_map: HashMap<_, _>);
-    #[cfg(not(feature = "std"))]
+
     crate::bench_encode_decode!(btree_map: BTreeMap<_, _>);
+    #[cfg(feature = "std")]
+    crate::bench_encode_decode!(hash_map: std::collections::HashMap<_, _>);
 }

--- a/src/derive/map.rs
+++ b/src/derive/map.rs
@@ -6,9 +6,9 @@ use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "std")]
-use std::collections::HashMap;
-#[cfg(feature = "std")]
 use core::hash::{BuildHasher, Hash};
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 pub struct MapEncoder<K: Encode, V: Encode> {
     lengths: LengthEncoder,

--- a/src/derive/map.rs
+++ b/src/derive/map.rs
@@ -1,6 +1,9 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::derive::{Decode, Encode};
 use crate::length::{LengthDecoder, LengthEncoder};
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 use std::collections::{BTreeMap, HashMap};
 use std::hash::{BuildHasher, Hash};
 use std::num::NonZeroUsize;

--- a/src/derive/map.rs
+++ b/src/derive/map.rs
@@ -4,9 +4,11 @@ use crate::length::{LengthDecoder, LengthEncoder};
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
-use std::collections::{BTreeMap, HashMap};
-use std::hash::{BuildHasher, Hash};
-use std::num::NonZeroUsize;
+
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+#[cfg(feature = "std")]
+use core::hash::{BuildHasher, Hash};
 
 pub struct MapEncoder<K: Encode, V: Encode> {
     lengths: LengthEncoder,
@@ -101,9 +103,11 @@ impl<'a, K: Decode<'a> + Ord, V: Decode<'a>> Decoder<'a, BTreeMap<K, V>> for Map
     decode_body!(BTreeMap<K, V>);
 }
 
+#[cfg(feature = "std")]
 impl<K: Encode, V: Encode, S> Encoder<HashMap<K, V, S>> for MapEncoder<K, V> {
     encode_body!(HashMap<K, V, S>);
 }
+#[cfg(feature = "std")]
 impl<'a, K: Decode<'a> + Eq + Hash, V: Decode<'a>, S: BuildHasher + Default>
     Decoder<'a, HashMap<K, V, S>> for MapDecoder<'a, K, V>
 {
@@ -112,9 +116,15 @@ impl<'a, K: Decode<'a> + Eq + Hash, V: Decode<'a>, S: BuildHasher + Default>
 
 #[cfg(test)]
 mod test {
-    use std::collections::{BTreeMap, HashMap};
+    use alloc::collections::BTreeMap;
+    #[cfg(feature = "std")]
+    use std::collections::HashMap;
+
     fn bench_data<T: FromIterator<(u8, u8)>>() -> T {
         (0..=255).map(|k| (k, 0)).collect()
     }
+    #[cfg(feature = "std")]
     crate::bench_encode_decode!(btree_map: BTreeMap<_, _>, hash_map: HashMap<_, _>);
+    #[cfg(not(feature = "std"))]
+    crate::bench_encode_decode!(btree_map: BTreeMap<_, _>);
 }

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -1,7 +1,8 @@
 use crate::coder::{Buffer, Decoder, Encoder, View};
 use crate::consume::expect_eof;
 use crate::Error;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 mod array;
 mod duration;
@@ -108,6 +109,7 @@ impl crate::buffer::Buffer {
 #[cfg(test)]
 mod tests {
     use crate::{Decode, Encode};
+    use alloc::vec::Vec;
 
     #[test]
     fn decode() {

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -117,6 +117,7 @@ mod tests {
             ($v:expr, $t:ty) => {
                 let v = $v;
                 let encoded = super::encode::<$t>(&v);
+                #[cfg(feature = "std")]
                 println!("{:<24} {encoded:?}", stringify!($t));
                 assert_eq!(v, super::decode::<$t>(&encoded).unwrap());
             };

--- a/src/derive/option.rs
+++ b/src/derive/option.rs
@@ -2,8 +2,9 @@ use crate::coder::{Buffer, Decoder, Encoder, Result, View, MAX_VECTORED_CHUNK};
 use crate::derive::variant::{VariantDecoder, VariantEncoder};
 use crate::derive::{Decode, Encode};
 use crate::fast::{FastArrayVec, PushUnchecked};
-use std::mem::MaybeUninit;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
 
 pub struct OptionEncoder<T: Encode> {
     variants: VariantEncoder<2>,
@@ -36,7 +37,7 @@ impl<T: Encode> Encoder<Option<T>> for OptionEncoder<T> {
     {
         // Types with many vectorized encoders benefit from a &[&T] since encode_vectorized is still
         // faster even with the extra indirection. TODO vectored encoder count >= 8 instead of size_of.
-        if std::mem::size_of::<T>() >= 64 {
+        if core::mem::size_of::<T>() >= 64 {
             let mut uninit = MaybeUninit::uninit();
             let mut refs = FastArrayVec::<_, MAX_VECTORED_CHUNK>::new(&mut uninit);
 
@@ -119,6 +120,8 @@ impl<'a, T: Decode<'a>> Decoder<'a, Option<T>> for OptionDecoder<'a, T> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     #[rustfmt::skip]
     fn bench_data() -> Vec<Option<(u64, u32, u8, i32, u64, u32, u8, i32, u64, (u32, u8, i32, u64, u32, u8, i32))>> {
         crate::random_data(1000)
@@ -128,6 +131,8 @@ mod tests {
 
 #[cfg(test)]
 mod tests2 {
+    use alloc::vec::Vec;
+
     #[rustfmt::skip]
     fn bench_data() -> Vec<Option<u16>> {
         crate::random_data(1000)

--- a/src/derive/result.rs
+++ b/src/derive/result.rs
@@ -2,8 +2,9 @@ use crate::coder::{Buffer, Decoder, Encoder, View};
 use crate::derive::variant::{VariantDecoder, VariantEncoder};
 use crate::derive::{Decode, Encode};
 use crate::error::Error;
-use std::mem::MaybeUninit;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
 
 pub struct ResultEncoder<T: Encode, E: Encode> {
     variants: VariantEncoder<2>,
@@ -91,6 +92,8 @@ impl<'a, T: Decode<'a>, E: Decode<'a>> Decoder<'a, Result<T, E>> for ResultDecod
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     fn bench_data() -> Vec<Result<u32, u8>> {
         crate::random_data::<(bool, u32, u8)>(1000)
             .into_iter()

--- a/src/derive/smart_ptr.rs
+++ b/src/derive/smart_ptr.rs
@@ -1,7 +1,8 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::derive::{Decode, Encode};
-use std::num::NonZeroUsize;
-use std::ops::Deref;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
+use core::ops::Deref;
 
 pub struct DerefEncoder<T: Encode + ?Sized>(T::Encoder);
 
@@ -54,6 +55,8 @@ impl<'a, F: From<T>, T: Decode<'a>> Decoder<'a, F> for FromDecoder<'a, T> {
 #[cfg(test)]
 mod tests {
     use crate::{decode, encode};
+    use alloc::boxed::Box;
+    use alloc::string::ToString;
 
     #[test]
     fn box_() {

--- a/src/derive/variant.rs
+++ b/src/derive/variant.rs
@@ -1,7 +1,8 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::fast::{CowSlice, NextUnchecked, PushUnchecked, VecImpl};
 use crate::pack::{pack_bytes_less_than, unpack_bytes_less_than};
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct VariantEncoder<const N: usize>(VecImpl<u8>);
@@ -35,7 +36,7 @@ impl<const N: usize, const C_STYLE: bool> Default for VariantDecoder<'_, N, C_ST
     fn default() -> Self {
         Self {
             variants: Default::default(),
-            histogram: std::array::from_fn(|_| 0),
+            histogram: core::array::from_fn(|_| 0),
         }
     }
 }
@@ -70,6 +71,7 @@ impl<'a, const N: usize, const C_STYLE: bool> Decoder<'a, u8> for VariantDecoder
 #[cfg(test)]
 mod tests {
     use crate::{decode, encode, Decode, Encode};
+    use alloc::vec::Vec;
 
     #[allow(unused)]
     #[test]

--- a/src/derive/vec.rs
+++ b/src/derive/vec.rs
@@ -8,9 +8,9 @@ use core::mem::MaybeUninit;
 use core::num::NonZeroUsize;
 
 #[cfg(feature = "std")]
-use std::collections::HashSet;
-#[cfg(feature = "std")]
 use core::hash::{BuildHasher, Hash};
+#[cfg(feature = "std")]
+use std::collections::HashSet;
 
 pub struct VecEncoder<T: Encode> {
     // pub(crate) for arrayvec.rs

--- a/src/derive/vec.rs
+++ b/src/derive/vec.rs
@@ -365,28 +365,19 @@ impl<'a, T: Decode<'a>> Decoder<'a, VecDeque<T>> for VecDecoder<'a, T> {
 mod test {
     use alloc::collections::*;
     use alloc::vec::Vec;
-    #[cfg(feature = "std")]
-    use std::collections::*;
 
     fn bench_data<T: FromIterator<u8>>() -> T {
         (0..=255).collect()
     }
 
+    crate::bench_encode_decode!(
+        btree_set: BTreeSet<_>,
+        linked_list: LinkedList<_>,
+        vec: Vec<_>,
+        vec_deque: VecDeque<_>
+    );
     #[cfg(feature = "std")]
-    crate::bench_encode_decode!(
-        btree_set: BTreeSet<_>,
-        hash_set: HashSet<_>,
-        linked_list: LinkedList<_>,
-        vec: Vec<_>,
-        vec_deque: VecDeque<_>
-    );
-    #[cfg(not(feature = "std"))]
-    crate::bench_encode_decode!(
-        btree_set: BTreeSet<_>,
-        linked_list: LinkedList<_>,
-        vec: Vec<_>,
-        vec_deque: VecDeque<_>
-    );
+    crate::bench_encode_decode!(hash_set: std::collections::HashSet<_>);
 
     // BinaryHeap can't use bench_encode_decode because it doesn't implement PartialEq.
     #[bench]

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,4 +50,6 @@ impl Display for Error {
         f.write_str("bitcode error")
     }
 }
+#[cfg(feature = "std")]
+// TODO expose to no_std when error_in_core stabilized (https://github.com/rust-lang/rust/issues/103765)
 impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 #[cfg(debug_assertions)]
-use std::borrow::Cow;
-use std::fmt::{Debug, Display, Formatter};
+use alloc::borrow::Cow;
+use alloc::string::ToString;
+use core::fmt::{Debug, Display, Formatter};
 
 /// Short version of `Err(error("..."))`.
 pub fn err<T>(msg: &'static str) -> Result<T, Error> {
@@ -37,12 +38,12 @@ type ErrorImpl = ();
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Error(ErrorImpl);
 impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "Error({:?})", self.to_string())
     }
 }
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         #[cfg(debug_assertions)]
         return f.write_str(&self.0);
         #[cfg(not(debug_assertions))]

--- a/src/ext/arrayvec.rs
+++ b/src/ext/arrayvec.rs
@@ -4,7 +4,7 @@ use crate::derive::{Decode, Encode};
 use crate::error::err;
 use crate::str::{StrDecoder, StrEncoder};
 use arrayvec::{ArrayString, ArrayVec};
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 // TODO optimize ArrayVec impls and make ArrayString use them.
 impl<const N: usize> Encoder<ArrayString<N>> for StrEncoder {
@@ -111,7 +111,7 @@ fn as_slice_assert_len<T, const N: usize>(t: &ArrayVec<T, N>) -> &[T] {
     let s = t.as_slice();
     // Safety: ArrayVec<N> has length <= N. TODO replace with LengthDecoder<N>.
     if s.len() > N {
-        unsafe { std::hint::unreachable_unchecked() };
+        unsafe { core::hint::unreachable_unchecked() };
     }
     s
 }
@@ -173,6 +173,7 @@ impl<'a, T: Decode<'a>, const N: usize> Decode<'a> for ArrayVec<T, N> {
 #[cfg(test)]
 mod tests {
     use crate::{decode, encode};
+    use alloc::vec::Vec;
     use arrayvec::{ArrayString, ArrayVec};
 
     // Smaller set of tests for ArrayString than ArrayVec they share VecEncoder/LengthDecoder.

--- a/src/ext/glam.rs
+++ b/src/ext/glam.rs
@@ -1,4 +1,5 @@
 use super::impl_struct;
+use alloc::vec::Vec;
 use glam::*;
 
 trait Affine3AExt {
@@ -43,6 +44,7 @@ impl_glam!(bool, BVec2, BVec3, BVec4);
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
     use glam::Vec2;
     fn bench_data() -> Vec<Vec2> {
         crate::random_data(1000)

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -29,7 +29,7 @@ macro_rules! impl_struct {
                     )+
                 }
 
-                fn reserve(&mut self, additional: std::num::NonZeroUsize) {
+                fn reserve(&mut self, additional: core::num::NonZeroUsize) {
                     $(
                         self.$f.reserve(additional);
                     )+

--- a/src/fast.rs
+++ b/src/fast.rs
@@ -415,7 +415,10 @@ impl<'borrowed, T> CowSlice<'borrowed, T> {
     ///
     /// If self is not owned (set_owned hasn't been called).
     pub fn mut_owned<R>(&mut self, f: impl FnOnce(&mut Vec<T>) -> R) -> R {
-        assert!(core::ptr::eq(self.slice.ptr, self.vec.as_ptr()), "not owned");
+        assert!(
+            core::ptr::eq(self.slice.ptr, self.vec.as_ptr()),
+            "not owned"
+        );
         // Clear self.slice before mutating self.vec, so we don't point to freed memory.
         self.slice = [].as_slice().into();
         let ret = f(&mut self.vec);

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -57,10 +57,10 @@ fn histogram_parallel_u32(bytes: &[u8]) -> [u32; 256] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
     use rand::prelude::*;
     use rand_chacha::ChaCha20Rng;
     use test::{black_box, Bencher};
-    use alloc::vec::Vec;
 
     fn bench_data(n: usize) -> Vec<u8> {
         let mut rng = ChaCha20Rng::from_seed(Default::default());

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -60,10 +60,11 @@ mod tests {
     use rand::prelude::*;
     use rand_chacha::ChaCha20Rng;
     use test::{black_box, Bencher};
+    use alloc::vec::Vec;
 
     fn bench_data(n: usize) -> Vec<u8> {
         let mut rng = ChaCha20Rng::from_seed(Default::default());
-        std::iter::repeat_with(|| rng.gen_range(0..2))
+        core::iter::repeat_with(|| rng.gen_range(0..2))
             .take(crate::limit_bench_miri(n))
             .collect()
     }

--- a/src/int.rs
+++ b/src/int.rs
@@ -2,8 +2,8 @@ use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::error::err;
 use crate::fast::{CowSlice, NextUnchecked, PushUnchecked, SliceImpl, Unaligned, VecImpl};
 use crate::pack_ints::{pack_ints, unpack_ints, Int};
-use bytemuck::{CheckedBitPattern, NoUninit, Pod};
 use alloc::vec::Vec;
+use bytemuck::{CheckedBitPattern, NoUninit, Pod};
 use core::marker::PhantomData;
 use core::num::NonZeroUsize;
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -3,8 +3,9 @@ use crate::error::err;
 use crate::fast::{CowSlice, NextUnchecked, PushUnchecked, SliceImpl, Unaligned, VecImpl};
 use crate::pack_ints::{pack_ints, unpack_ints, Int};
 use bytemuck::{CheckedBitPattern, NoUninit, Pod};
-use std::marker::PhantomData;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct IntEncoder<T>(VecImpl<T>);
@@ -13,7 +14,7 @@ pub struct IntEncoder<T>(VecImpl<T>);
 impl<T: Int, P: NoUninit> Encoder<P> for IntEncoder<T> {
     #[inline(always)]
     fn as_primitive(&mut self) -> Option<&mut VecImpl<P>> {
-        use std::mem::*;
+        use core::mem::*;
         assert_eq!(align_of::<T>(), align_of::<P>());
         assert_eq!(size_of::<T>(), size_of::<P>());
         // Safety: size/align are equal, T: Int implies Pod, and caller isn't reading P which may be NonZero.
@@ -113,7 +114,7 @@ where
                 let p = p.cast::<Unaligned<C::Bits>>();
                 // Safety: `Unaligned<C::Bits>` and `Unaligned<C>` have the same layout and populate
                 // ensured C's bit pattern is valid.
-                unsafe { std::mem::transmute(p) }
+                unsafe { core::mem::transmute(p) }
             })
     }
 
@@ -122,14 +123,15 @@ where
         let v: I = self.0.decode();
         let v: C::Bits = bytemuck::must_cast(v);
         // Safety: C::Bits and C have the same layout and populate ensured C's bit pattern is valid.
-        unsafe { std::mem::transmute_copy(&v) }
+        unsafe { core::mem::transmute_copy(&v) }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{decode, encode};
-    use std::num::NonZeroU32;
+    use alloc::vec::Vec;
+    use core::num::NonZeroU32;
 
     #[test]
     fn non_zero_u32() {
@@ -151,6 +153,8 @@ mod tests {
 
 #[cfg(test)]
 mod test2 {
+    use alloc::vec::Vec;
+
     fn bench_data() -> Vec<Vec<u16>> {
         crate::random_data::<u8>(125)
             .into_iter()

--- a/src/length.rs
+++ b/src/length.rs
@@ -3,7 +3,8 @@ use crate::error::{err, error};
 use crate::fast::{CowSlice, NextUnchecked, VecImpl};
 use crate::int::{IntDecoder, IntEncoder};
 use crate::pack::{pack_bytes, unpack_bytes};
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct LengthEncoder {
@@ -213,7 +214,7 @@ impl<'a> Decoder<'a, usize> for LengthDecoder<'a> {
         // Allows some checks in Vec::with_capacity to be removed if lto = true.
         // Safety: sum < HUGE_LEN is checked in populate so all elements have to be < HUGE_LEN.
         if length as u64 >= HUGE_LEN {
-            unsafe { std::hint::unreachable_unchecked() }
+            unsafe { core::hint::unreachable_unchecked() }
         }
         length
     }
@@ -223,7 +224,7 @@ impl<'a> Decoder<'a, usize> for LengthDecoder<'a> {
 mod tests {
     use super::{LengthDecoder, LengthEncoder};
     use crate::coder::{Buffer, Decoder, Encoder, View};
-    use std::num::NonZeroUsize;
+    use core::num::NonZeroUsize;
 
     #[test]
     fn test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 #![cfg_attr(test, feature(test))]
 #![doc = include_str!("../README.md")]
 
+#[macro_use]
+extern crate alloc;
+
 // Fixes derive macro in tests/doc tests.
 #[cfg(test)]
 extern crate self as bitcode;
@@ -44,6 +47,9 @@ pub use crate::serde::*;
 mod benches;
 #[cfg(test)]
 mod benches_borrowed;
+
+#[cfg(test)]
+use alloc::vec::Vec;
 
 #[cfg(test)]
 fn random_data<T>(n: usize) -> Vec<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 
 #[macro_use]

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -687,6 +687,7 @@ mod tests {
                 .collect();
             let n = bytes.len(); // random_data shrinks n on miri.
 
+            #[cfg(feature = "std")]
             println!("n {n}, N {N}, FACTOR {FACTOR}");
             if N != FACTOR {
                 let mut bytes = bytes.clone();

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -3,6 +3,7 @@ use crate::consume::{consume_byte, consume_byte_arrays, consume_bytes};
 use crate::error::err;
 use crate::fast::CowSlice;
 use crate::pack_ints::SizedInt;
+use alloc::vec::Vec;
 
 /// Possible states per byte in descending order. Each packed byte will use `log2(states)` bits.
 #[repr(u8)]
@@ -68,7 +69,7 @@ pub fn unpack_bools(input: &mut &[u8], length: usize, out: &mut CowSlice<bool>) 
     let mut set_owned = out.set_owned();
     let out: &mut Vec<bool> = &mut set_owned;
     // Safety: u8 and bool have same size/align and `out` will only contain bytes that are 0 or 1.
-    let out: &mut Vec<u8> = unsafe { std::mem::transmute(out) };
+    let out: &mut Vec<u8> = unsafe { core::mem::transmute(out) };
     unpack_arithmetic::<2>(input, length, out)
 }
 
@@ -224,7 +225,7 @@ pub fn unpack_bytes_less_than<'a, const N: usize, const HISTOGRAM: usize>(
         if FACTOR > N && unpacked.iter().copied().max().unwrap_or(0) as usize >= N {
             return invalid_packing();
         }
-        Ok(std::array::from_fn(|_| unreachable!("HISTOGRAM not 0")))
+        Ok(core::array::from_fn(|_| unreachable!("HISTOGRAM not 0")))
     }
 
     /// Returns `Ok(histogram)` if buckets after `OUT` are 0.
@@ -295,7 +296,7 @@ pub fn unpack_bytes_less_than<'a, const N: usize, const HISTOGRAM: usize>(
                     let partial = partial_with_garbage << (divisor - partial_length);
                     one_count += partial.count_ones() as usize;
                 }
-                Ok(std::array::from_fn(|i| match i {
+                Ok(core::array::from_fn(|i| match i {
                     0 => length - one_count,
                     1 => one_count,
                     _ => unreachable!(),
@@ -353,7 +354,7 @@ fn unpack_histogram<const FACTOR: usize, const FACTOR_POW_DIVISOR: usize>(
 ) -> [usize; FACTOR] {
     let divisor = factor_to_divisor::<FACTOR>();
     assert_eq!(FACTOR.pow(divisor as u32), FACTOR_POW_DIVISOR);
-    std::array::from_fn(|i| {
+    core::array::from_fn(|i| {
         let mut sum = 0;
         for level in 0..divisor {
             let width = FACTOR.pow(level as u32);
@@ -408,7 +409,7 @@ fn pack_arithmetic<const FACTOR: usize>(bytes: &[u8], out: &mut Vec<u8>) {
                     // Could use on any pow2 FACTOR, but only 2 is faster (target-cpu=native).
                     let chunk = (bytes.as_ptr() as *const u8 as *const [u8; 8]).add(i);
                     let chunk = u64::from_le_bytes(*chunk);
-                    std::arch::x86_64::_pext_u64(chunk, 0x0101010101010101) as u8
+                    core::arch::x86_64::_pext_u64(chunk, 0x0101010101010101) as u8
                 }
             } else {
                 let mut acc = 0;
@@ -458,7 +459,7 @@ fn unpack_arithmetic<const FACTOR: usize>(
                 #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
                 {
                     // Could use on any pow2 FACTOR, but only 2 is faster (target-cpu=native).
-                    let chunk = std::arch::x86_64::_pdep_u64(packed as u64, 0x0101010101010101);
+                    let chunk = core::arch::x86_64::_pdep_u64(packed as u64, 0x0101010101010101);
                     *(unpacked.as_mut_ptr() as *mut [u8; 8]).add(i) = chunk.to_le_bytes();
                 }
             } else {
@@ -484,6 +485,8 @@ fn unpack_arithmetic<const FACTOR: usize>(
 #[cfg(test)]
 mod tests {
     use crate::error::err;
+    use alloc::borrow::ToOwned;
+    use alloc::vec::Vec;
     use paste::paste;
     use test::{black_box, Bencher};
 

--- a/src/pack_ints.rs
+++ b/src/pack_ints.rs
@@ -4,6 +4,7 @@ use crate::error::error;
 use crate::fast::CowSlice;
 use crate::pack::{invalid_packing, pack_bytes, unpack_bytes};
 use crate::Error;
+use alloc::vec::Vec;
 use bytemuck::Pod;
 
 /// Possible integer sizes in descending order.
@@ -58,7 +59,7 @@ fn usize_too_big() -> Error {
     error("encountered a isize/usize with more than 32 bits on a 32 bit platform")
 }
 
-pub trait Int: Copy + std::fmt::Debug + Default + Ord + Pod + Send + Sized + Sync {
+pub trait Int: Copy + core::fmt::Debug + Default + Ord + Pod + Send + Sized + Sync {
     // Unaligned native endian. TODO could be aligned on big endian since we always have to copy.
     type Une: Pod + Default + Send + Sync;
     type Int: SizedInt;
@@ -81,7 +82,7 @@ macro_rules! impl_usize_and_isize {
     ($($isize:ident => $i64:ident),+) => {
         $(
             impl Int for $isize {
-                type Une = [u8; std::mem::size_of::<Self>()];
+                type Une = [u8; core::mem::size_of::<Self>()];
                 type Int = $i64;
                 fn with_input(ints: &mut [Self], f: impl FnOnce(&mut [Self::Int])) {
                     if cfg!(target_pointer_width = "64") {
@@ -125,7 +126,7 @@ macro_rules! impl_int {
     ($($int:ident => $uint:ident),+) => {
         $(
             impl Int for $int {
-                type Une = [u8; std::mem::size_of::<Self>()];
+                type Une = [u8; core::mem::size_of::<Self>()];
                 type Int = Self;
                 fn with_input(ints: &mut [Self], f: impl FnOnce(&mut [Self::Int])) {
                     f(ints)
@@ -236,7 +237,7 @@ macro_rules! impl_smaller {
 // In theory, we could avoid this intermediate step, but it would result in a lot of generated code.
 fn with_scratch<T>(f: impl FnOnce(&mut Vec<u8>) -> T) -> T {
     thread_local! {
-        static SCRATCH: std::cell::RefCell<Vec<u8>> = Default::default();
+        static SCRATCH: core::cell::RefCell<Vec<u8>> = Default::default();
     }
     SCRATCH.with(|s| {
         let s = &mut s.borrow_mut();
@@ -255,7 +256,7 @@ macro_rules! impl_u8 {
         fn unpack8(input: &mut &[u8], length: usize, out: &mut CowSlice<Self::Une>) -> Result<()> {
             with_scratch(|allocation| {
                 // unpack_bytes might not result in a copy, but if it does we want to avoid an allocation.
-                let mut bytes = CowSlice::with_allocation(std::mem::take(allocation));
+                let mut bytes = CowSlice::with_allocation(core::mem::take(allocation));
                 unpack_bytes(input, length, &mut bytes)?;
                 // Safety: unpack_bytes ensures bytes has length of `length`.
                 let slice = unsafe { bytes.as_slice(length) };
@@ -331,14 +332,14 @@ pub fn minmax<T: SizedInt>(v: &[T]) -> (T, T) {
 
 fn skip_packing<T: SizedInt>(length: usize) -> bool {
     // Be careful using size_of::<T> since usize can be 4 or 8.
-    if std::mem::size_of::<T>() == 1 {
+    if core::mem::size_of::<T>() == 1 {
         return true; // u8s can't be packed by pack_ints (only pack_bytes).
     }
     if length == 0 {
         return true; // Can't pack 0 ints.
     }
     // Packing a single u16 is pointless (takes at least 2 bytes).
-    std::mem::size_of::<T>() == 2 && length == 1
+    core::mem::size_of::<T>() == 2 && length == 1
 }
 
 /// Like [`pack_bytes`] but for larger integers. Handles endian conversion.
@@ -351,7 +352,7 @@ fn pack_ints_sized<T: SizedInt>(ints: &mut [T], out: &mut Vec<u8>) {
     // Handle i8 right away since pack_bytes needs to know that it's signed.
     // If we didn't have this special case [0i8, -1, 0, -1, 0, -1] couldn't be packed.
     // Doesn't affect larger signed ints because they're made positive before pack_bytes::<u8> is called.
-    if std::mem::size_of::<T>() == 1 && T::MIN < T::default() {
+    if core::mem::size_of::<T>() == 1 && T::MIN < T::default() {
         let ints: &mut [i8] = bytemuck::must_cast_slice_mut(ints);
         pack_bytes(ints, out);
         return;
@@ -477,6 +478,8 @@ fn unpack_ints_sized_unsigned<'a, T: SizedUInt>(
 mod tests {
     use super::{usize_too_big, CowSlice, Int, Result};
     use crate::error::err;
+    use alloc::borrow::ToOwned;
+    use alloc::vec::Vec;
     use test::{black_box, Bencher};
 
     pub fn pack_ints<T: Int>(ints: &[T]) -> Vec<u8> {
@@ -512,7 +515,7 @@ mod tests {
             let b = unpack_ints::<usize>(&packed, a.len());
             if cfg!(target_pointer_width = "64") {
                 let b = b.unwrap();
-                assert_eq!(a, std::array::from_fn(|i| b[i] as u64));
+                assert_eq!(a, core::array::from_fn(|i| b[i] as u64));
             } else {
                 assert_eq!(b.unwrap_err(), usize_too_big());
             }
@@ -527,7 +530,7 @@ mod tests {
             let b = unpack_ints::<isize>(&packed, a.len());
             if cfg!(target_pointer_width = "64") {
                 let b = b.unwrap();
-                assert_eq!(a, std::array::from_fn(|i| b[i] as i64));
+                assert_eq!(a, core::array::from_fn(|i| b[i] as i64));
             } else {
                 assert_eq!(b.unwrap_err(), usize_too_big());
             }
@@ -625,7 +628,7 @@ mod tests {
 
     fn bench_pack_ints<T: Int>(b: &mut Bencher, src: &[T]) {
         let mut ints = src.to_vec();
-        let mut out = Vec::with_capacity(std::mem::size_of_val(src) + 10);
+        let mut out = Vec::with_capacity(core::mem::size_of_val(src) + 10);
         let starting_cap = out.capacity();
         b.iter(|| {
             ints.copy_from_slice(&src);
@@ -679,7 +682,7 @@ mod tests {
                 fn [<bench_pack_ $name _no_pack>](b: &mut Bencher) {
                     let src = vec![$t::MIN; 1000];
                     let mut ints = src.clone();
-                    let mut out: Vec<u8> = Vec::with_capacity(std::mem::size_of_val(&ints) + 10);
+                    let mut out: Vec<u8> = Vec::with_capacity(core::mem::size_of_val(&ints) + 10);
                     b.iter(|| {
                         ints.copy_from_slice(&src);
                         let input = black_box(&mut ints);

--- a/src/pack_ints.rs
+++ b/src/pack_ints.rs
@@ -237,7 +237,7 @@ macro_rules! impl_smaller {
 // In theory, we could avoid this intermediate step, but it would result in a lot of generated code.
 fn with_scratch<T>(f: impl FnOnce(&mut Vec<u8>) -> T) -> T {
     thread_local! {
-        static SCRATCH: core::cell::RefCell<Vec<u8>> = Default::default();
+        static SCRATCH: core::cell::RefCell<Vec<u8>> = const { core::cell::RefCell::new(Vec::new()) }
     }
     SCRATCH.with(|s| {
         let s = &mut s.borrow_mut();

--- a/src/pack_ints.rs
+++ b/src/pack_ints.rs
@@ -569,10 +569,12 @@ mod tests {
         let out = pack_ints(&mut ints.to_owned());
         let unpacked = unpack_ints::<T>(&out, ints.len()).unwrap();
         assert_eq!(unpacked, ints);
-
-        let packing = out[0];
-        let size = 100.0 * out.len() as f32 / std::mem::size_of_val(ints) as f32;
-        println!("{packing} {size:>5.1}%");
+        #[cfg(feature = "std")]
+        {
+            let packing = out[0];
+            let size = 100.0 * out.len() as f32 / core::mem::size_of_val(ints) as f32;
+            println!("{packing} {size:>5.1}%");
+        }
         out
     }
 
@@ -597,15 +599,18 @@ mod tests {
                         let Ok(start) = T::try_from(max) else {
                             continue;
                         };
+                        #[cfg(feature = "std")]
                         let s = format!("{start} {increment}");
                         if increment == 1 {
-                           print!("{s:<19} mod 2 => ");
-                           test_inner::<T>(&std::array::from_fn::<_, 100, _>(|i| {
-                               start + (i as T % 2) * increment
-                           }));
+                            #[cfg(feature = "std")]
+                            print!("{s:<19} mod 2 => ");
+                            test_inner::<T>(&core::array::from_fn::<_, 100, _>(|i| {
+                                start + (i as T % 2) * increment
+                            }));
                         }
+                        #[cfg(feature = "std")]
                         print!("{s:<25} => ");
-                        test_inner::<T>(&std::array::from_fn::<_, 100, _>(|i| {
+                        test_inner::<T>(&core::array::from_fn::<_, 100, _>(|i| {
                             start + i as T * increment
                         }));
                     }

--- a/src/pack_ints.rs
+++ b/src/pack_ints.rs
@@ -235,6 +235,7 @@ macro_rules! impl_smaller {
 
 // Scratch space to bridge gap between pack_ints and pack_bytes.
 // In theory, we could avoid this intermediate step, but it would result in a lot of generated code.
+#[cfg(feature = "std")]
 fn with_scratch<T>(f: impl FnOnce(&mut Vec<u8>) -> T) -> T {
     thread_local! {
         static SCRATCH: core::cell::RefCell<Vec<u8>> = const { core::cell::RefCell::new(Vec::new()) }
@@ -245,6 +246,7 @@ fn with_scratch<T>(f: impl FnOnce(&mut Vec<u8>) -> T) -> T {
         f(s)
     })
 }
+#[cfg(feature = "std")]
 macro_rules! impl_u8 {
     () => {
         fn pack8(v: &mut [Self], out: &mut Vec<u8>) {
@@ -265,6 +267,27 @@ macro_rules! impl_u8 {
                 *allocation = bytes.into_allocation();
                 Ok(())
             })
+        }
+    };
+}
+#[cfg(not(feature = "std"))]
+macro_rules! impl_u8 {
+    () => {
+        fn pack8(v: &mut [Self], out: &mut Vec<u8>) {
+            // resort to allocation
+            let mut bytes: Vec<_> = v.iter().map(|&v| v as u8).collect();
+            pack_bytes(&mut bytes, out);
+        }
+        fn unpack8(input: &mut &[u8], length: usize, out: &mut CowSlice<Self::Une>) -> Result<()> {
+            // resort to allocation
+            let allocation: Vec<u8> = Vec::with_capacity(length);
+            let mut bytes = CowSlice::with_allocation(allocation);
+            unpack_bytes(input, length, &mut bytes)?;
+            // Safety: unpack_bytes ensures bytes has length of `length`.
+            let slice = unsafe { bytes.as_slice(length) };
+            out.set_owned()
+                .extend(slice.iter().map(|&v| (v as Self).to_ne_bytes()));
+            Ok(())
         }
     };
 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -119,8 +119,8 @@ macro_rules! specify {
                 #[cold]
                 fn cold<'de>(decoder: &mut SerdeDecoder<'de>, input: &mut &'de [u8]) -> Result<()> {
                     let &mut SerdeDecoder::Unspecified { length } = decoder else {
-                        type_changed!();
-                    };
+                            type_changed!();
+                        };
                     *decoder = SerdeDecoder::$variant(Default::default());
                     decoder.populate(input, length)
                 }
@@ -128,10 +128,10 @@ macro_rules! specify {
             }
         }
         let SerdeDecoder::$variant(d) = &mut *$self.decoder else {
-            // Safety: `cold` gets called when decoder isn't the correct decoder. `cold` either
-            // errors or sets lazy to the correct decoder.
-            unsafe { core::hint::unreachable_unchecked() };
-        };
+                // Safety: `cold` gets called when decoder isn't the correct decoder. `cold` either
+                // errors or sets lazy to the correct decoder.
+                unsafe { core::hint::unreachable_unchecked() };
+            };
         d
     }};
 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -571,12 +571,12 @@ impl<'de> VariantAccess<'de> for DecoderWrapper<'_, 'de> {
 
 #[cfg(test)]
 mod tests {
-    use serde::de::MapAccess;
-    use serde::Deserializer;
     use alloc::borrow::ToOwned;
     use alloc::collections::BTreeMap;
     use alloc::string::String;
     use alloc::vec::Vec;
+    use serde::de::MapAccess;
+    use serde::Deserializer;
 
     #[test]
     fn deserialize() {

--- a/src/serde/guard.rs
+++ b/src/serde/guard.rs
@@ -14,7 +14,7 @@ fn check_zst_len(len: usize) -> Result<()> {
 // Used by deserialize. Guards against Vec<()> with huge len taking forever.
 #[inline]
 pub fn guard_zst<T>(len: usize) -> Result<()> {
-    if std::mem::size_of::<T>() == 0 {
+    if core::mem::size_of::<T>() == 0 {
         check_zst_len(len)
     } else {
         Ok(())

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,5 +1,7 @@
 use crate::error::{error_from_display, Error};
-use std::fmt::Display;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt::Display;
 
 mod de;
 mod guard;
@@ -36,6 +38,9 @@ fn get_mut_or_resize<T: Default>(vec: &mut Vec<T>, index: usize) -> &mut T {
     // Safety we've just resized `vec.len()` to be > than `index`.
     unsafe { vec.get_unchecked_mut(index) }
 }
+
+//#[cfg(not(feature = "std"))]
+impl serde::ser::StdError for Error {}
 
 impl serde::ser::Error for Error {
     fn custom<T>(t: T) -> Self

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -39,7 +39,7 @@ fn get_mut_or_resize<T: Default>(vec: &mut Vec<T>, index: usize) -> &mut T {
     unsafe { vec.get_unchecked_mut(index) }
 }
 
-//#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "std"))]
 impl serde::ser::StdError for Error {}
 
 impl serde::ser::Error for Error {

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -7,14 +7,14 @@ use crate::length::LengthEncoder;
 use crate::serde::variant::VariantEncoder;
 use crate::serde::{default_box_slice, get_mut_or_resize, type_changed};
 use crate::str::StrEncoder;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 use serde::ser::{
     SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant,
 };
 use serde::{Serialize, Serializer};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use core::num::NonZeroUsize;
 
 // Redefine Result from crate::coder::Result to std::result::Result since the former isn't public.
 mod inner {
@@ -587,9 +587,9 @@ impl SerializeMap for MapSerializer<'_> {
 
 #[cfg(test)]
 mod tests {
+    use core::num::NonZeroUsize;
     use serde::ser::{SerializeMap, SerializeSeq, SerializeTuple};
     use serde::{Serialize, Serializer};
-    use core::num::NonZeroUsize;
 
     #[test]
     fn enum_256_variants() {

--- a/src/serde/variant.rs
+++ b/src/serde/variant.rs
@@ -1,8 +1,9 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::fast::{CowSlice, NextUnchecked, PushUnchecked, VecImpl};
 use crate::pack::{pack_bytes, unpack_bytes};
-use std::marker::PhantomData;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct VariantEncoder {

--- a/src/str.rs
+++ b/src/str.rs
@@ -5,8 +5,11 @@ use crate::error::err;
 use crate::fast::{NextUnchecked, SliceImpl};
 use crate::length::LengthDecoder;
 use crate::u8_char::U8Char;
-use std::num::NonZeroUsize;
-use std::str::{from_utf8, from_utf8_unchecked};
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
+use core::str::{from_utf8, from_utf8_unchecked};
 
 #[derive(Default)]
 pub struct StrEncoder(pub(crate) VecEncoder<U8Char>); // pub(crate) for arrayvec.rs
@@ -161,6 +164,7 @@ mod tests {
     use super::is_ascii_simd;
     use crate::u8_char::U8Char;
     use crate::{decode, encode};
+    use alloc::borrow::ToOwned;
     use test::{black_box, Bencher};
 
     #[test]
@@ -205,6 +209,9 @@ mod tests {
 
 #[cfg(test)]
 mod tests2 {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
     fn bench_data() -> Vec<String> {
         crate::random_data::<u8>(40000)
             .into_iter()

--- a/src/u8_char.rs
+++ b/src/u8_char.rs
@@ -1,7 +1,8 @@
 use crate::coder::{Buffer, Encoder};
 use crate::derive::Encode;
 use crate::fast::VecImpl;
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 /// Represents a single byte of a string, unlike u8 which represents an integer.
 #[derive(Copy, Clone)]


### PR DESCRIPTION
Adds `#![no_std]` (with `alloc`) compatibility by introducing a `"std"` cargo feature.

I'm interested in evaluating bitcode for embedded applications. I found adding support relatively painless, most of the changes are swapping `use std::*` for `use::core::*`, and adding explicit use of `alloc`.

Notable changes:
* `HashMap` and `HashSet` implementations for `Decode` and `Encode` are disabled for `no_std`
* Added an unrelated improvement to the `thread_local` [here](https://github.com/SoftbearStudios/bitcode/compare/main...poshcoe:bitcode:no-std-compat?expand=1#diff-d47e861d674c037988d4f1bcf5bba333e59a3b37b42346c537fa0b3da7f09081R241), utilising the const syntax which should improve efficiency by avoiding runtime initialisation checks.
* As `thread_local!` is `std`-only, I added a separate [`impl_u8!`](https://github.com/SoftbearStudios/bitcode/compare/main...poshcoe:bitcode:no-std-compat?expand=1#diff-d47e861d674c037988d4f1bcf5bba333e59a3b37b42346c537fa0b3da7f09081R274) which falls-back to allocating the "scratch space" on each `pack8`/`unpack8` call. See below images for benchmarks on the impact of this change (`target_arch = "x86_64"`).

`cargo +nightly bench bench_pack`:

![Screenshot_20240419_104158](https://github.com/SoftbearStudios/bitcode/assets/26864647/b90c0772-f5a6-4dc1-a75d-656eb3fa5b0e)

`cargo +nightly bench bench_unpack_u`:

![Screenshot_20240419_124131](https://github.com/SoftbearStudios/bitcode/assets/26864647/e6c41c32-0e4f-4bea-a779-44811aaf8186)

At a glance the performance impact is minimal, resulting in a < 1% average performance deficit on both pack and unpack without `std`.

It remains to be seen if bitcode performs well on no_std target architectures. I'll likely be testing this in the near future.