### PR TITLE
feat: add `#[bitcode(crate = "...")]` for crate alias

### DIFF
--- a/bitcode_derive/src/attribute.rs
+++ b/bitcode_derive/src/attribute.rs
@@ -41,8 +41,12 @@ impl BitcodeAttr {
                         _ => return err(&expr, "expected path string e.g. \"my_crate::bitcode\""),
                     };
 
-                    let path = syn::parse_str(&str_lit.value())
+                    let mut path = syn::parse_str::<Path>(&str_lit.value())
                         .map_err(|e| error(str_lit, &e.to_string()))?;
+
+                    // ensure there's a leading `::`
+                    path.leading_colon = Some(Token![::](str_lit.span()));
+
                     Ok(Self::CrateAlias(path))
                 }
                 _ => err(&nested, "expected name value"),

--- a/bitcode_derive/src/attribute.rs
+++ b/bitcode_derive/src/attribute.rs
@@ -7,6 +7,7 @@ use syn::{parse2, Attribute, Expr, ExprLit, Lit, Meta, Path, Result, Token, Type
 
 enum BitcodeAttr {
     BoundType(Type),
+    CrateAlias(Path),
 }
 
 impl BitcodeAttr {
@@ -30,6 +31,22 @@ impl BitcodeAttr {
                 }
                 _ => err(&nested, "expected name value"),
             },
+            "crate" => match nested {
+                Meta::NameValue(name_value) => {
+                    let expr = &name_value.value;
+                    let str_lit = match expr {
+                        Expr::Lit(ExprLit {
+                            lit: Lit::Str(v), ..
+                        }) => v,
+                        _ => return err(&expr, "expected path string e.g. \"my_crate::bitcode\""),
+                    };
+
+                    let path = syn::parse_str(&str_lit.value())
+                        .map_err(|e| error(str_lit, &e.to_string()))?;
+                    Ok(Self::CrateAlias(path))
+                }
+                _ => err(&nested, "expected name value"),
+            },
             _ => err(&nested, "unknown attribute"),
         }
     }
@@ -47,6 +64,14 @@ impl BitcodeAttr {
                     err(nested, "can only apply bound to fields")
                 }
             }
+            Self::CrateAlias(crate_name) => {
+                if let AttrType::Derive = attrs.attr_type {
+                    attrs.crate_name = crate_name;
+                    Ok(())
+                } else {
+                    err(nested, "can only apply crate rename to derives")
+                }
+            }
         }
     }
 }
@@ -54,6 +79,8 @@ impl BitcodeAttr {
 #[derive(Clone)]
 pub struct BitcodeAttrs {
     attr_type: AttrType,
+    /// The crate name to use for the generated code, defaults to "bitcode".
+    pub crate_name: Path,
 }
 
 #[derive(Clone)]
@@ -65,7 +92,10 @@ enum AttrType {
 
 impl BitcodeAttrs {
     fn new(attr_type: AttrType) -> Self {
-        Self { attr_type }
+        Self {
+            attr_type,
+            crate_name: syn::parse_str("bitcode").expect("invalid crate name"),
+        }
     }
 
     pub fn bound_type(&self) -> Option<Type> {

--- a/bitcode_derive/src/lib.rs
+++ b/bitcode_derive/src/lib.rs
@@ -35,5 +35,5 @@ pub(crate) fn err<T>(spanned: &impl Spanned, s: &str) -> Result<T, Error> {
 }
 
 pub(crate) fn private(crate_name: &syn::Path) -> proc_macro2::TokenStream {
-    quote! { ::#crate_name::__private }
+    quote! { #crate_name::__private }
 }

--- a/bitcode_derive/src/lib.rs
+++ b/bitcode_derive/src/lib.rs
@@ -34,6 +34,6 @@ pub(crate) fn err<T>(spanned: &impl Spanned, s: &str) -> Result<T, Error> {
     Err(error(spanned, s))
 }
 
-pub(crate) fn private() -> proc_macro2::TokenStream {
-    quote! { bitcode::__private }
+pub(crate) fn private(crate_name: &syn::Path) -> proc_macro2::TokenStream {
+    quote! { ::#crate_name::__private }
 }


### PR DESCRIPTION
Currently it's not possible to package up the `bitcode` crate's derives without requiring users to include the dependency locally (cluttering up their deps list if they don't actually use it).

This PR adds an optional crate attribute that overrides all references to the crate with a new name.

```toml
bitcode_renamed = { package = "bitcode", version = "0.6" }
```

```rust
#[derive(bitcode_renamed::Encode)]
#[bitcode(crate = "bitcode_renamed")]
pub struct MyData {
  // ...
}
```

It also works with paths, e.g.

```rust
#[bitcode(crate = "some::other::location")]
```