### PR TITLE
Add support for `std::net::{*Addr*}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ If you have multiple values of the same type:
 - Validation is performed up front on typed vectors before deserialization
 - Code is designed to be auto-vectorized by LLVM
 
+## `serde`
+A `serde` integration is gated behind the `"serde"` feature flag. It is slower, produces
+slightly larger output, and (by extension) is not compatible with the native
+`bitcode::{Encode, Decode}`. Note that:
+- the `serde` version does not support types like
+`serde_json::Value`, which internally serialize different types (numbers, arrays, etc.)
+without a normal enum discriminant.
+- the `serde` version omits
+the `flowinfo` and `scope_id` fields of `std::net::SocketAddrV6`, but native `bitcode`
+keeps them.
+
 ## `#![no_std]`
 All `std`-only functionality is gated behind the (default) `"std"` feature.
 

--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::num::NonZeroU32;
 use std::time::Duration;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4};
 
 #[inline(never)]
 fn test_derive<T: Debug + PartialEq + Encode + DecodeOwned>(data: &[u8]) {
@@ -213,5 +213,6 @@ fuzz_target!(|data: &[u8]| {
         Ipv4Addr,
         Ipv6Addr,
         IpAddr,
+        SocketAddrV4,
     );
 });

--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::num::NonZeroU32;
 use std::time::Duration;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 #[inline(never)]
 fn test_derive<T: Debug + PartialEq + Encode + DecodeOwned>(data: &[u8]) {
@@ -209,5 +210,8 @@ fuzz_target!(|data: &[u8]| {
         ArrayVec<u8, 5>,
         ArrayVec<u8, 70>,
         Duration,
+        Ipv4Addr,
+        Ipv6Addr,
+        IpAddr,
     );
 });

--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::num::NonZeroU32;
 use std::time::Duration;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddr, SocketAddrV6};
 
 #[inline(never)]
 fn test_derive<T: Debug + PartialEq + Encode + DecodeOwned>(data: &[u8]) {
@@ -214,5 +214,7 @@ fuzz_target!(|data: &[u8]| {
         Ipv6Addr,
         IpAddr,
         SocketAddrV4,
+        SocketAddrV6,
+        SocketAddr,
     );
 });

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -197,18 +197,18 @@ macro_rules! impl_convert {
 
 #[cfg(feature = "std")]
 macro_rules! impl_ipvx_addr {
-    ($addr: ident) => {
+    ($addr: ident, $repr: ident) => {
         impl_convert!(
             std::net::$addr,
-            [u8; core::mem::size_of::<std::net::$addr>()]
+            $repr
         );
     };
 }
 
 #[cfg(feature = "std")]
-impl_ipvx_addr!(Ipv4Addr);
+impl_ipvx_addr!(Ipv4Addr, u32);
 #[cfg(feature = "std")]
-impl_ipvx_addr!(Ipv6Addr);
+impl_ipvx_addr!(Ipv6Addr, u128);
 #[cfg(feature = "std")]
 impl_convert!(std::net::IpAddr, super::ip_addr::IpAddrConversion);
 #[cfg(feature = "std")]

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -211,6 +211,8 @@ impl_ipvx_addr!(Ipv4Addr);
 impl_ipvx_addr!(Ipv6Addr);
 #[cfg(feature = "std")]
 impl_convert!(std::net::IpAddr, core::result::Result<std::net::Ipv4Addr, std::net::Ipv6Addr>);
+#[cfg(feature = "std")]
+impl_convert!(std::net::SocketAddrV4, (std::net::Ipv4Addr, u16));
 
 impl<T> Encode for PhantomData<T> {
     type Encoder = EmptyCoder;

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -198,10 +198,7 @@ macro_rules! impl_convert {
 #[cfg(feature = "std")]
 macro_rules! impl_ipvx_addr {
     ($addr: ident, $repr: ident) => {
-        impl_convert!(
-            std::net::$addr,
-            $repr
-        );
+        impl_convert!(std::net::$addr, $repr);
     };
 }
 

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -1,4 +1,3 @@
-use super::ip_addr::{ConvertFromDecoder, ConvertIntoEncoder};
 use crate::bool::{BoolDecoder, BoolEncoder};
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::derive::array::{ArrayDecoder, ArrayEncoder};
@@ -184,29 +183,34 @@ impl<'a, T: Decode<'a>, E: Decode<'a>> Decode<'a> for core::result::Result<T, E>
     type Decoder = ResultDecoder<'a, T, E>;
 }
 
+#[cfg(feature = "std")]
 macro_rules! impl_convert {
     ($want: path, $have: ty) => {
         impl Encode for $want {
-            type Encoder = ConvertIntoEncoder<$have>;
+            type Encoder = super::ip_addr::ConvertIntoEncoder<$have>;
         }
         impl<'a> Decode<'a> for $want {
-            type Decoder = ConvertFromDecoder<'a, $have>;
+            type Decoder = super::ip_addr::ConvertFromDecoder<'a, $have>;
         }
     };
 }
 
+#[cfg(feature = "std")]
 macro_rules! impl_ipvx_addr {
     ($addr: ident) => {
         impl_convert!(
-            core::net::$addr,
-            [u8; core::mem::size_of::<core::net::$addr>()]
+            std::net::$addr,
+            [u8; core::mem::size_of::<std::net::$addr>()]
         );
     };
 }
 
+#[cfg(feature = "std")]
 impl_ipvx_addr!(Ipv4Addr);
+#[cfg(feature = "std")]
 impl_ipvx_addr!(Ipv6Addr);
-impl_convert!(core::net::IpAddr, core::result::Result<core::net::Ipv4Addr, core::net::Ipv6Addr>);
+#[cfg(feature = "std")]
+impl_convert!(std::net::IpAddr, core::result::Result<std::net::Ipv4Addr, std::net::Ipv6Addr>);
 
 impl<T> Encode for PhantomData<T> {
     type Encoder = EmptyCoder;

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -206,7 +206,7 @@ macro_rules! impl_ipvx_addr {
 
 impl_ipvx_addr!(Ipv4Addr);
 impl_ipvx_addr!(Ipv6Addr);
-impl_convert!(core::net::IpAddr, std::result::Result<core::net::Ipv4Addr, core::net::Ipv6Addr>);
+impl_convert!(core::net::IpAddr, core::result::Result<core::net::Ipv4Addr, core::net::Ipv6Addr>);
 
 impl<T> Encode for PhantomData<T> {
     type Encoder = EmptyCoder;

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -210,9 +210,19 @@ impl_ipvx_addr!(Ipv4Addr);
 #[cfg(feature = "std")]
 impl_ipvx_addr!(Ipv6Addr);
 #[cfg(feature = "std")]
-impl_convert!(std::net::IpAddr, core::result::Result<std::net::Ipv4Addr, std::net::Ipv6Addr>);
+impl_convert!(std::net::IpAddr, super::ip_addr::IpAddrConversion);
 #[cfg(feature = "std")]
-impl_convert!(std::net::SocketAddrV4, (std::net::Ipv4Addr, u16));
+impl_convert!(
+    std::net::SocketAddrV4,
+    super::ip_addr::SocketAddrV4Conversion
+);
+#[cfg(feature = "std")]
+impl_convert!(
+    std::net::SocketAddrV6,
+    super::ip_addr::SocketAddrV6Conversion
+);
+#[cfg(feature = "std")]
+impl_convert!(std::net::SocketAddr, super::ip_addr::SocketAddrConversion);
 
 impl<T> Encode for PhantomData<T> {
     type Encoder = EmptyCoder;

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -1,18 +1,18 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::derive::{Decode, Encode};
-use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use core::num::NonZeroUsize;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 macro_rules! ipvx_addr {
     ($addr: ident) => {
-        impl ConvertFrom<&core::net::$addr> for [u8; core::mem::size_of::<core::net::$addr>()] {
-            fn convert_from(ip: &core::net::$addr) -> Self {
+        impl ConvertFrom<&$addr> for [u8; std::mem::size_of::<$addr>()] {
+            fn convert_from(ip: &$addr) -> Self {
                 ip.octets()
             }
         }
 
-        impl ConvertFrom<[u8; core::mem::size_of::<core::net::$addr>()]> for core::net::$addr {
-            fn convert_from(octets: [u8; core::mem::size_of::<core::net::$addr>()]) -> Self {
+        impl ConvertFrom<[u8; std::mem::size_of::<$addr>()]> for $addr {
+            fn convert_from(octets: [u8; std::mem::size_of::<$addr>()]) -> Self {
                 Self::from(octets)
             }
         }
@@ -22,7 +22,7 @@ macro_rules! ipvx_addr {
 ipvx_addr!(Ipv4Addr);
 ipvx_addr!(Ipv6Addr);
 
-impl ConvertFrom<&IpAddr> for core::result::Result<Ipv4Addr, Ipv6Addr> {
+impl ConvertFrom<&IpAddr> for std::result::Result<Ipv4Addr, Ipv6Addr> {
     fn convert_from(value: &IpAddr) -> Self {
         match value {
             IpAddr::V4(v4) => Ok(*v4),
@@ -31,8 +31,8 @@ impl ConvertFrom<&IpAddr> for core::result::Result<Ipv4Addr, Ipv6Addr> {
     }
 }
 
-impl ConvertFrom<core::result::Result<Ipv4Addr, Ipv6Addr>> for IpAddr {
-    fn convert_from(value: core::result::Result<Ipv4Addr, Ipv6Addr>) -> Self {
+impl ConvertFrom<std::result::Result<Ipv4Addr, Ipv6Addr>> for IpAddr {
+    fn convert_from(value: std::result::Result<Ipv4Addr, Ipv6Addr>) -> Self {
         match value {
             Ok(v4) => Self::V4(v4),
             Err(v6) => Self::V6(v6),

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -1,0 +1,94 @@
+use crate::coder::{Buffer, Decoder, Encoder, Result, View};
+use crate::derive::{Decode, Encode};
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::num::NonZeroUsize;
+
+macro_rules! ipvx_addr {
+    ($addr: ident) => {
+        impl ConvertFrom<&core::net::$addr> for [u8; std::mem::size_of::<core::net::$addr>()] {
+            fn convert_from(ip: &core::net::$addr) -> Self {
+                ip.octets()
+            }
+        }
+
+        impl ConvertFrom<[u8; std::mem::size_of::<core::net::$addr>()]> for core::net::$addr {
+            fn convert_from(octets: [u8; std::mem::size_of::<core::net::$addr>()]) -> Self {
+                Self::from(octets)
+            }
+        }
+    };
+}
+
+ipvx_addr!(Ipv4Addr);
+ipvx_addr!(Ipv6Addr);
+
+impl ConvertFrom<&IpAddr> for std::result::Result<Ipv4Addr, Ipv6Addr> {
+    fn convert_from(value: &IpAddr) -> Self {
+        match value {
+            IpAddr::V4(v4) => Ok(*v4),
+            IpAddr::V6(v6) => Err(*v6),
+        }
+    }
+}
+
+impl ConvertFrom<std::result::Result<Ipv4Addr, Ipv6Addr>> for IpAddr {
+    fn convert_from(value: std::result::Result<Ipv4Addr, Ipv6Addr>) -> Self {
+        match value {
+            Ok(v4) => Self::V4(v4),
+            Err(v6) => Self::V6(v6),
+        }
+    }
+}
+
+// Like [`From`] but we can implement it ourselves.
+pub(crate) trait ConvertFrom<T>: Sized {
+    fn convert_from(value: T) -> Self;
+}
+
+pub struct ConvertIntoEncoder<T: Encode>(T::Encoder);
+
+// Can't derive since it would bound T: Default.
+impl<T: Encode> Default for ConvertIntoEncoder<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<D, T: Encode + for<'a> ConvertFrom<&'a D>> Encoder<D> for ConvertIntoEncoder<T> {
+    #[inline(always)]
+    fn encode(&mut self, t: &D) {
+        self.0.encode(&T::convert_from(t));
+    }
+}
+
+impl<T: Encode> Buffer for ConvertIntoEncoder<T> {
+    fn collect_into(&mut self, out: &mut Vec<u8>) {
+        self.0.collect_into(out);
+    }
+    fn reserve(&mut self, additional: NonZeroUsize) {
+        self.0.reserve(additional);
+    }
+}
+
+/// Decodes a `T` and then converts it with [`ConvertFrom`]. For `T` -> `Box<T>` and `Vec<T>` -> `Box<[T]>`.
+pub struct ConvertFromDecoder<'a, T: Decode<'a>>(T::Decoder);
+
+// Can't derive since it would bound T: Default.
+impl<'a, T: Decode<'a>> Default for ConvertFromDecoder<'a, T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<'a, T: Decode<'a>> View<'a> for ConvertFromDecoder<'a, T> {
+    fn populate(&mut self, input: &mut &'a [u8], length: usize) -> Result<()> {
+        self.0.populate(input, length)
+    }
+}
+
+impl<'a, F: ConvertFrom<T>, T: Decode<'a>> Decoder<'a, F> for ConvertFromDecoder<'a, T> {
+    #[inline(always)]
+    fn decode(&mut self) -> F {
+        F::convert_from(self.0.decode())
+    }
+}

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -1,5 +1,6 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::derive::{Decode, Encode};
+use core::net::SocketAddrV4;
 use core::num::NonZeroUsize;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -37,6 +38,18 @@ impl ConvertFrom<std::result::Result<Ipv4Addr, Ipv6Addr>> for IpAddr {
             Ok(v4) => Self::V4(v4),
             Err(v6) => Self::V6(v6),
         }
+    }
+}
+
+impl ConvertFrom<&SocketAddrV4> for (Ipv4Addr, u16) {
+    fn convert_from(value: &SocketAddrV4) -> Self {
+        (*value.ip(), value.port())
+    }
+}
+
+impl ConvertFrom<(Ipv4Addr, u16)> for SocketAddrV4 {
+    fn convert_from((ip, port): (Ipv4Addr, u16)) -> Self {
+        Self::new(ip, port)
     }
 }
 

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -4,23 +4,23 @@ use core::num::NonZeroUsize;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 macro_rules! ipvx_addr {
-    ($addr: ident) => {
-        impl ConvertFrom<&$addr> for [u8; std::mem::size_of::<$addr>()] {
+    ($addr: ident, $repr: ident) => {
+        impl ConvertFrom<&$addr> for $repr {
             fn convert_from(ip: &$addr) -> Self {
-                ip.octets()
+                (*ip).into()
             }
         }
 
-        impl ConvertFrom<[u8; std::mem::size_of::<$addr>()]> for $addr {
-            fn convert_from(octets: [u8; std::mem::size_of::<$addr>()]) -> Self {
-                Self::from(octets)
+        impl ConvertFrom<$repr> for $addr {
+            fn convert_from(bits: $repr) -> Self {
+                Self::from(bits)
             }
         }
     };
 }
 
-ipvx_addr!(Ipv4Addr);
-ipvx_addr!(Ipv6Addr);
+ipvx_addr!(Ipv4Addr, u32);
+ipvx_addr!(Ipv6Addr, u128);
 
 pub(crate) type IpAddrConversion = std::result::Result<Ipv4Addr, Ipv6Addr>;
 

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -1,8 +1,7 @@
 use crate::coder::{Buffer, Decoder, Encoder, Result, View};
 use crate::derive::{Decode, Encode};
-use core::net::SocketAddrV4;
 use core::num::NonZeroUsize;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV4};
 
 macro_rules! ipvx_addr {
     ($addr: ident) => {

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -70,7 +70,7 @@ impl<T: Encode> Buffer for ConvertIntoEncoder<T> {
     }
 }
 
-/// Decodes a `T` and then converts it with [`ConvertFrom`]. For `T` -> `Box<T>` and `Vec<T>` -> `Box<[T]>`.
+/// Decodes a `T` and then converts it with [`ConvertFrom`].
 pub struct ConvertFromDecoder<'a, T: Decode<'a>>(T::Decoder);
 
 // Can't derive since it would bound T: Default.

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -5,14 +5,14 @@ use core::num::NonZeroUsize;
 
 macro_rules! ipvx_addr {
     ($addr: ident) => {
-        impl ConvertFrom<&core::net::$addr> for [u8; std::mem::size_of::<core::net::$addr>()] {
+        impl ConvertFrom<&core::net::$addr> for [u8; core::mem::size_of::<core::net::$addr>()] {
             fn convert_from(ip: &core::net::$addr) -> Self {
                 ip.octets()
             }
         }
 
-        impl ConvertFrom<[u8; std::mem::size_of::<core::net::$addr>()]> for core::net::$addr {
-            fn convert_from(octets: [u8; std::mem::size_of::<core::net::$addr>()]) -> Self {
+        impl ConvertFrom<[u8; core::mem::size_of::<core::net::$addr>()]> for core::net::$addr {
+            fn convert_from(octets: [u8; core::mem::size_of::<core::net::$addr>()]) -> Self {
                 Self::from(octets)
             }
         }
@@ -22,7 +22,7 @@ macro_rules! ipvx_addr {
 ipvx_addr!(Ipv4Addr);
 ipvx_addr!(Ipv6Addr);
 
-impl ConvertFrom<&IpAddr> for std::result::Result<Ipv4Addr, Ipv6Addr> {
+impl ConvertFrom<&IpAddr> for core::result::Result<Ipv4Addr, Ipv6Addr> {
     fn convert_from(value: &IpAddr) -> Self {
         match value {
             IpAddr::V4(v4) => Ok(*v4),
@@ -31,8 +31,8 @@ impl ConvertFrom<&IpAddr> for std::result::Result<Ipv4Addr, Ipv6Addr> {
     }
 }
 
-impl ConvertFrom<std::result::Result<Ipv4Addr, Ipv6Addr>> for IpAddr {
-    fn convert_from(value: std::result::Result<Ipv4Addr, Ipv6Addr>) -> Self {
+impl ConvertFrom<core::result::Result<Ipv4Addr, Ipv6Addr>> for IpAddr {
+    fn convert_from(value: core::result::Result<Ipv4Addr, Ipv6Addr>) -> Self {
         match value {
             Ok(v4) => Self::V4(v4),
             Err(v6) => Self::V6(v6),

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -8,6 +8,7 @@ mod array;
 mod duration;
 mod empty;
 mod impls;
+mod ip_addr;
 mod map;
 mod option;
 mod result;

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -8,6 +8,9 @@ mod array;
 mod duration;
 mod empty;
 mod impls;
+// TODO: When ip_in_core has been stable (https://github.com/rust-lang/rust/issues/108443)
+// for long enough, remove feature check.
+#[cfg(feature = "std")]
 mod ip_addr;
 mod map;
 mod option;

--- a/src/derive/smart_ptr.rs
+++ b/src/derive/smart_ptr.rs
@@ -29,7 +29,7 @@ impl<T: Encode + ?Sized> Buffer for DerefEncoder<T> {
     }
 }
 
-/// Decodes a `T` and then converts it with [`From`]. For `T` -> `Box<T>` and `Vec<T>` -> `Box<[T]>`.
+/// Decodes a `T` and then converts it with [`From`]. For example `T` -> `Box<T>` and `Vec<T>` -> `Box<[T]>`.
 pub struct FromDecoder<'a, T: Decode<'a>>(T::Decoder);
 
 // Can't derive since it would bound T: Default.

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,9 +19,7 @@ pub fn error(_msg: &'static str) -> Error {
 #[cfg(feature = "serde")]
 pub fn error_from_display(_t: impl Display) -> Error {
     #[cfg(debug_assertions)]
-    use alloc::string::ToString;
-    #[cfg(debug_assertions)]
-    return Error(Cow::Owned(_t.to_string()));
+    return Error(Cow::Owned(alloc::string::ToString::to_string(&_t)));
     #[cfg(not(debug_assertions))]
     Error(())
 }


### PR DESCRIPTION
Works by converting them to/from existing implementations like `Result<Ipv4Addr, Ipv6Addr>`, `u32`, `u128`, and `(Ipv4Addr, u16)`. This is to avoid additional `unsafe` code. Manual re-implementation might yield better performance.