### PR TITLE
Move convert encoder out of IP addr module.

### DIFF
--- a/src/derive/convert.rs
+++ b/src/derive/convert.rs
@@ -1,0 +1,56 @@
+use crate::coder::{Buffer, Decoder, Encoder, Result, View};
+use crate::derive::{Decode, Encode};
+use core::num::NonZeroUsize;
+
+// Like [`From`] but we can implement it ourselves.
+pub(crate) trait ConvertFrom<T>: Sized {
+    fn convert_from(value: T) -> Self;
+}
+
+pub struct ConvertIntoEncoder<T: Encode>(T::Encoder);
+
+// Can't derive since it would bound T: Default.
+impl<T: Encode> Default for ConvertIntoEncoder<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<D, T: Encode + for<'a> ConvertFrom<&'a D>> Encoder<D> for ConvertIntoEncoder<T> {
+    #[inline(always)]
+    fn encode(&mut self, t: &D) {
+        self.0.encode(&T::convert_from(t));
+    }
+}
+
+impl<T: Encode> Buffer for ConvertIntoEncoder<T> {
+    fn collect_into(&mut self, out: &mut Vec<u8>) {
+        self.0.collect_into(out);
+    }
+    fn reserve(&mut self, additional: NonZeroUsize) {
+        self.0.reserve(additional);
+    }
+}
+
+/// Decodes a `T` and then converts it with [`ConvertFrom`].
+pub struct ConvertFromDecoder<'a, T: Decode<'a>>(T::Decoder);
+
+// Can't derive since it would bound T: Default.
+impl<'a, T: Decode<'a>> Default for ConvertFromDecoder<'a, T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<'a, T: Decode<'a>> View<'a> for ConvertFromDecoder<'a, T> {
+    fn populate(&mut self, input: &mut &'a [u8], length: usize) -> Result<()> {
+        self.0.populate(input, length)
+    }
+}
+
+impl<'a, F: ConvertFrom<T>, T: Decode<'a>> Decoder<'a, F> for ConvertFromDecoder<'a, T> {
+    #[inline(always)]
+    fn decode(&mut self) -> F {
+        F::convert_from(self.0.decode())
+    }
+}

--- a/src/derive/convert.rs
+++ b/src/derive/convert.rs
@@ -24,7 +24,7 @@ impl<D, T: Encode + for<'a> ConvertFrom<&'a D>> Encoder<D> for ConvertIntoEncode
 }
 
 impl<T: Encode> Buffer for ConvertIntoEncoder<T> {
-    fn collect_into(&mut self, out: &mut Vec<u8>) {
+    fn collect_into(&mut self, out: &mut alloc::vec::Vec<u8>) {
         self.0.collect_into(out);
     }
     fn reserve(&mut self, additional: NonZeroUsize) {

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -187,10 +187,10 @@ impl<'a, T: Decode<'a>, E: Decode<'a>> Decode<'a> for core::result::Result<T, E>
 macro_rules! impl_convert {
     ($want: path, $have: ty) => {
         impl Encode for $want {
-            type Encoder = super::ip_addr::ConvertIntoEncoder<$have>;
+            type Encoder = super::convert::ConvertIntoEncoder<$have>;
         }
         impl<'a> Decode<'a> for $want {
-            type Decoder = super::ip_addr::ConvertFromDecoder<'a, $have>;
+            type Decoder = super::convert::ConvertFromDecoder<'a, $have>;
         }
     };
 }

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -1,7 +1,5 @@
-use crate::coder::{Buffer, Decoder, Encoder, Result, View};
-use crate::derive::{Decode, Encode};
-use core::num::NonZeroUsize;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use super::convert::ConvertFrom;
 
 macro_rules! ipvx_addr {
     ($addr: ident, $repr: ident) => {
@@ -92,58 +90,5 @@ impl ConvertFrom<SocketAddrConversion> for SocketAddr {
             Ok(v4) => Self::V4(v4),
             Err(v6) => Self::V6(v6),
         }
-    }
-}
-
-// Like [`From`] but we can implement it ourselves.
-pub(crate) trait ConvertFrom<T>: Sized {
-    fn convert_from(value: T) -> Self;
-}
-
-pub struct ConvertIntoEncoder<T: Encode>(T::Encoder);
-
-// Can't derive since it would bound T: Default.
-impl<T: Encode> Default for ConvertIntoEncoder<T> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
-
-impl<D, T: Encode + for<'a> ConvertFrom<&'a D>> Encoder<D> for ConvertIntoEncoder<T> {
-    #[inline(always)]
-    fn encode(&mut self, t: &D) {
-        self.0.encode(&T::convert_from(t));
-    }
-}
-
-impl<T: Encode> Buffer for ConvertIntoEncoder<T> {
-    fn collect_into(&mut self, out: &mut Vec<u8>) {
-        self.0.collect_into(out);
-    }
-    fn reserve(&mut self, additional: NonZeroUsize) {
-        self.0.reserve(additional);
-    }
-}
-
-/// Decodes a `T` and then converts it with [`ConvertFrom`].
-pub struct ConvertFromDecoder<'a, T: Decode<'a>>(T::Decoder);
-
-// Can't derive since it would bound T: Default.
-impl<'a, T: Decode<'a>> Default for ConvertFromDecoder<'a, T> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
-
-impl<'a, T: Decode<'a>> View<'a> for ConvertFromDecoder<'a, T> {
-    fn populate(&mut self, input: &mut &'a [u8], length: usize) -> Result<()> {
-        self.0.populate(input, length)
-    }
-}
-
-impl<'a, F: ConvertFrom<T>, T: Decode<'a>> Decoder<'a, F> for ConvertFromDecoder<'a, T> {
-    #[inline(always)]
-    fn decode(&mut self) -> F {
-        F::convert_from(self.0.decode())
     }
 }

--- a/src/derive/ip_addr.rs
+++ b/src/derive/ip_addr.rs
@@ -1,5 +1,5 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use super::convert::ConvertFrom;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 macro_rules! ipvx_addr {
     ($addr: ident, $repr: ident) => {

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -5,6 +5,7 @@ use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 
 mod array;
+mod convert;
 mod duration;
 mod empty;
 mod impls;

--- a/src/pack_ints.rs
+++ b/src/pack_ints.rs
@@ -592,6 +592,7 @@ mod tests {
             fn $name() {
                 type T = $t;
                 for increment in [0, 1, u8::MAX as u128 + 1, u16::MAX as u128 + 1, u32::MAX as u128 + 1, u64::MAX as u128 + 1] {
+                    #[allow(irrefutable_let_patterns)]
                     let Ok(increment) = T::try_from(increment) else {
                         continue;
                     };
@@ -603,6 +604,7 @@ mod tests {
                         if max == T::MAX as i128 {
                             continue;
                         }
+                        #[allow(irrefutable_let_patterns)]
                         let Ok(start) = T::try_from(max) else {
                             continue;
                         };


### PR DESCRIPTION
The convert encoder is generally useful.

e.g. #33, #38