### PR TITLE
Add support for serde::serialize_into()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "bitcode"
 authors = [ "Cai Bear", "Finn Bear" ]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/SoftbearStudios/bitcode"


### PR DESCRIPTION
Expose `serde::serialize_into()` to allow users to specify their own serialization buffer and remove one `Vec` allocation. I would also like to remove the allocation of the boxed slice for the reordering buffer, but I couldn't come up with anything elegant.