### PR TITLE
Use explicit crate root for core qualifications

### DIFF
--- a/bitcode_derive/src/decode.rs
+++ b/bitcode_derive/src/decode.rs
@@ -165,7 +165,7 @@ impl crate::shared::Item for Item {
                 if never {
                     return quote! {
                         // Safety: View::populate will error on length != 0 so decode won't be called.
-                        unsafe { core::hint::unreachable_unchecked() }
+                        unsafe { ::core::hint::unreachable_unchecked() }
                     };
                 }
                 let pattern = |i: usize| {
@@ -197,7 +197,7 @@ impl crate::shared::Item for Item {
                             match self.variants.decode() {
                                 #variants
                                 // Safety: VariantDecoder<N, _>::decode outputs numbers less than N.
-                                _ => unsafe { core::hint::unreachable_unchecked() }
+                                _ => unsafe { ::core::hint::unreachable_unchecked() }
                             }
                         }
                     })
@@ -276,7 +276,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
 
         let [mut type_body, mut default_body, populate_body, decode_in_place_body] = output;
         if type_body.is_empty() {
-            type_body = quote! { __spooky: core::marker::PhantomData<&#de ()>, };
+            type_body = quote! { __spooky: ::core::marker::PhantomData<&#de ()>, };
         }
         if default_body.is_empty() {
             default_body = quote! { __spooky: Default::default(), };
@@ -298,7 +298,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
                 }
 
                 // Avoids bounding #impl_generics: Default.
-                impl #decoder_impl_generics core::default::Default for #decoder_ty #decoder_where_clause {
+                impl #decoder_impl_generics ::core::default::Default for #decoder_ty #decoder_where_clause {
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -315,7 +315,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
 
                 impl #impl_generics #private::Decoder<#de, #input_ty> for #decoder_ty #where_clause {
                     #[cfg_attr(not(debug_assertions), inline(always))]
-                    fn decode_in_place(&mut self, out: &mut core::mem::MaybeUninit<#input_ty>) {
+                    fn decode_in_place(&mut self, out: &mut ::core::mem::MaybeUninit<#input_ty>) {
                         #decode_in_place_body
                     }
                 }

--- a/bitcode_derive/src/encode.rs
+++ b/bitcode_derive/src/encode.rs
@@ -53,7 +53,7 @@ impl crate::shared::Item for Item {
                     // does not exist. Instead we replace this with <T<'static> as Encode>::Encoder and transmute it to
                     // T<'a>. No encoder actually encodes T<'static> any differently from T<'a> so this is sound.
                     quote! {
-                        unsafe { core::mem::transmute::<&#underscore_type, &#static_type>(#field_name) }
+                        unsafe { ::core::mem::transmute::<&#underscore_type, &#static_type>(#field_name) }
                     }
                 } else {
                     quote! { #field_name }
@@ -159,7 +159,7 @@ impl crate::shared::Item for Item {
                             .then(|| {
                                 let reserve = inner(Self::Reserve, i);
                                 quote! {
-                                    let __additional = core::num::NonZeroUsize::MIN;
+                                    let __additional = ::core::num::NonZeroUsize::MIN;
                                     #reserve
                                 }
                             })
@@ -265,7 +265,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
                 }
 
                 // Avoids bounding #impl_generics: Default.
-                impl #encoder_impl_generics core::default::Default for #encoder_ty #encoder_where_clause {
+                impl #encoder_impl_generics ::core::default::Default for #encoder_ty #encoder_where_clause {
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -295,7 +295,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
                         #collect_into_body
                     }
 
-                    fn reserve(&mut self, __additional: core::num::NonZeroUsize) {
+                    fn reserve(&mut self, __additional: ::core::num::NonZeroUsize) {
                         #reserve_body
                     }
                 }

--- a/src/coder.rs
+++ b/src/coder.rs
@@ -102,8 +102,8 @@ pub trait Decoder<'a, T>: View<'a> + Default + Send + Sync {
 macro_rules! __private_uninit_field {
     ($uninit:ident.$field:tt:$field_ty:ty) => {
         unsafe {
-            &mut *(core::ptr::addr_of_mut!((*$uninit.as_mut_ptr()).$field)
-                as *mut core::mem::MaybeUninit<$field_ty>)
+            &mut *(::core::ptr::addr_of_mut!((*$uninit.as_mut_ptr()).$field)
+                as *mut ::core::mem::MaybeUninit<$field_ty>)
         }
     };
 }


### PR DESCRIPTION
Update references to `core` to use `::core` to avoid collisions with local user modules in derive macros

closes #56 