### PR TITLE
Version bump 0.6.5 / fix #59 - use exact `bitcode_derive`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "bitcode"
 authors = [ "Cai Bear", "Finn Bear" ]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/SoftbearStudios/bitcode"
@@ -15,7 +15,7 @@ exclude = ["fuzz/"]
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false, optional = true }
-bitcode_derive = { version = "=0.6.4", path = "./bitcode_derive", optional = true }
+bitcode_derive = { version = "=0.6.5", path = "./bitcode_derive", optional = true }
 bytemuck = { version = "1.14", features = [ "min_const_generics", "must_cast" ] }
 glam = { version = ">=0.21", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = [ "alloc" ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["fuzz/"]
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false, optional = true }
-bitcode_derive = { version = "0.6.4", path = "./bitcode_derive", optional = true }
+bitcode_derive = { version = "=0.6.4", path = "./bitcode_derive", optional = true }
 bytemuck = { version = "1.14", features = [ "min_const_generics", "must_cast" ] }
 glam = { version = ">=0.21", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = [ "alloc" ], optional = true }

--- a/bitcode_derive/Cargo.toml
+++ b/bitcode_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcode_derive"
 authors = [ "Cai Bear", "Finn Bear" ]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/SoftbearStudios/bitcode/"


### PR DESCRIPTION
- Version bump 0.6.5
  - Fixes #59
  - Use explicit crate root for core qualifications #57 