### PR TITLE
Only add implementation for `Arc` if the target supports it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install thumbv6m-none-eabi
         run: rustup target add thumbv6m-none-eabi
       - name: Check (no atomic ptr)
-        run: cargo check --target thumbv6m-none-eabi --no-default-features --features derive,serde,glam,arrayvec
+        run: cargo check --target thumbv6m-none-eabi --no-default-features --features derive,serde,arrayvec
       - name: Setup Miri
         run: cargo miri setup
       - name: Test (miri all-features)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
         run: cargo test --target i686-unknown-linux-gnu --all-features
       - name: Install thumbv6m-none-eabi
         run: rustup target add thumbv6m-none-eabi
-      - name: Test (no atomic ptr)
-        run: cargo test --target thumbv6m-none-eabi --no-default-features --features derive,serde,glam,arrayvec
+      - name: Check (no atomic ptr)
+        run: cargo check --target thumbv6m-none-eabi --no-default-features --features derive,serde,glam,arrayvec
       - name: Setup Miri
         run: cargo miri setup
       - name: Test (miri all-features)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
         run: rustup target add i686-unknown-linux-gnu && sudo apt update && sudo apt install -y gcc-multilib
       - name: Test (32-bit all-features)
         run: cargo test --target i686-unknown-linux-gnu --all-features
+      - name: Install thumbv6m-none-eabi
+        run: rustup target add thumbv6m-none-eabi
+      - name: Test (no atomic ptr)
+        run: cargo test --target thumbv6m-none-eabi --no-default-features --features derive,serde,glam,arrayvec
       - name: Setup Miri
         run: cargo miri setup
       - name: Test (miri all-features)

--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -109,6 +109,7 @@ macro_rules! impl_smart_ptr {
 }
 impl_smart_ptr!(::alloc::boxed::Box);
 impl_smart_ptr!(::alloc::rc::Rc);
+#[cfg(target_has_atomic = "ptr")]
 impl_smart_ptr!(::alloc::sync::Arc);
 
 impl<T: Encode, const N: usize> Encode for [T; N] {


### PR DESCRIPTION
Currently the `Encode` and `Decode` traits are always implemented for `alloc::sync::Arc` regardless of whether the `Arc` type is actually available. When compiling to a target that does not have atomic pointers (e.g. thumbv6m-none-eabi) the compiler emits the following error message:

```
error[E0433]: failed to resolve: could not find `sync` in `alloc`
   --> src/derive/impls.rs:112:26
    |
112 | impl_smart_ptr!(::alloc::sync::Arc);
    |                          ^^^^ could not find `sync` in `alloc`
    |
note: found an item that was configured out
   --> /nix/store/awlsysagj2w76yjz13w9sqfh5ws4zv73-rust-nightly/lib/rustlib/src/rust/library/alloc/src/lib.rs:228:9
    |
228 | pub mod sync;
    |         ^^^^
note: the item is gated here
   --> /nix/store/awlsysagj2w76yjz13w9sqfh5ws4zv73-rust-nightly/lib/rustlib/src/rust/library/alloc/src/lib.rs:227:1
    |
227 | #[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0433`.
error: could not compile `bitcode` (lib) due to 1 previous error
```

With this change the traits are only implemented if the `Arc` type exists.