### PR TITLE
Add support for Encode and Decode of Pin<Box<T>>

### DIFF
--- a/src/derive/impls.rs
+++ b/src/derive/impls.rs
@@ -5,7 +5,7 @@ use crate::derive::empty::EmptyCoder;
 use crate::derive::map::{MapDecoder, MapEncoder};
 use crate::derive::option::{OptionDecoder, OptionEncoder};
 use crate::derive::result::{ResultDecoder, ResultEncoder};
-use crate::derive::smart_ptr::{DerefEncoder, FromDecoder};
+use crate::derive::smart_ptr::{DerefEncoder, FromDecoder, PinDecoder, PinEncoder};
 use crate::derive::vec::{VecDecoder, VecEncoder};
 use crate::derive::{Decode, Encode};
 use crate::f32::{F32Decoder, F32Encoder};
@@ -17,6 +17,8 @@ use alloc::vec::Vec;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::num::*;
+use core::ops::Deref;
+use core::pin::Pin;
 
 macro_rules! impl_both {
     ($t:ty, $encoder:ident, $decoder:ident) => {
@@ -110,6 +112,19 @@ impl_smart_ptr!(::alloc::boxed::Box);
 impl_smart_ptr!(::alloc::rc::Rc);
 #[cfg(target_has_atomic = "ptr")]
 impl_smart_ptr!(::alloc::sync::Arc);
+
+impl<P: Deref + Encode> Encode for Pin<P>
+where
+    P::Target: Encode,
+{
+    type Encoder = PinEncoder<P>;
+}
+impl<'a, P: Decode<'a>> Decode<'a> for Pin<P>
+where
+    Pin<P>: From<P>,
+{
+    type Decoder = PinDecoder<'a, P>;
+}
 
 impl<T: Encode, const N: usize> Encode for [T; N] {
     type Encoder = ArrayEncoder<T, N>;

--- a/src/derive/smart_ptr.rs
+++ b/src/derive/smart_ptr.rs
@@ -52,11 +52,15 @@ impl<'a, F: From<T>, T: Decode<'a>> Decoder<'a, F> for FromDecoder<'a, T> {
     }
 }
 
+pub type PinEncoder<P> = DerefEncoder<<P as Deref>::Target>;
+pub type PinDecoder<'a, P> = FromDecoder<'a, P>;
+
 #[cfg(test)]
 mod tests {
     use crate::{decode, encode};
     use alloc::boxed::Box;
     use alloc::string::ToString;
+    use core::pin::Pin;
 
     #[test]
     fn box_() {
@@ -74,5 +78,11 @@ mod tests {
     fn box_str() {
         let v = "box".to_string().into_boxed_str();
         assert_eq!(decode::<Box<str>>(&encode(&v)).unwrap(), v);
+    }
+
+    #[test]
+    fn pin_box_i32() {
+        let v = Box::pin(7i32);
+        assert_eq!(decode::<Pin<Box<i32>>>(&encode(&v)).unwrap(), v);
     }
 }


### PR DESCRIPTION
Allows for encoding and decoding things like `Pin<Box<T>>`.

Closes #104 