### PR TITLE
Disable #[inline(always)] for derived structs in debug mode.

### DIFF
--- a/bitcode_derive/src/decode.rs
+++ b/bitcode_derive/src/decode.rs
@@ -334,7 +334,6 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
 
                 // Avoids bounding #impl_generics: Default.
                 impl #decoder_impl_generics ::core::default::Default for #decoder_ty #decoder_where_clause {
-                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -343,7 +342,6 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
                 }
 
                 impl #decoder_impl_generics #private::View<#de> for #decoder_ty #decoder_where_clause {
-                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn populate(&mut self, input: &mut &#de [u8], __length: usize) -> #private::Result<()> {
                         #populate_body
                         Ok(())

--- a/bitcode_derive/src/decode.rs
+++ b/bitcode_derive/src/decode.rs
@@ -321,6 +321,9 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
             #[allow(clippy::pedantic)]
             const _: () = {
                 impl #impl_generics #private::Decode<#de> for #input_ty #where_clause {
+                    #[cfg(debug_assertions)]
+                    type Decoder = #private::BoxDecoder<#decoder_ty>;
+                    #[cfg(not(debug_assertions))]
                     type Decoder = #decoder_ty;
                 }
 

--- a/bitcode_derive/src/decode.rs
+++ b/bitcode_derive/src/decode.rs
@@ -331,6 +331,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
 
                 // Avoids bounding #impl_generics: Default.
                 impl #decoder_impl_generics ::core::default::Default for #decoder_ty #decoder_where_clause {
+                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -339,6 +340,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Decode {
                 }
 
                 impl #decoder_impl_generics #private::View<#de> for #decoder_ty #decoder_where_clause {
+                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn populate(&mut self, input: &mut &#de [u8], __length: usize) -> #private::Result<()> {
                         #populate_body
                         Ok(())

--- a/bitcode_derive/src/encode.rs
+++ b/bitcode_derive/src/encode.rs
@@ -287,7 +287,6 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
 
                 // Avoids bounding #impl_generics: Default.
                 impl #encoder_impl_generics ::core::default::Default for #encoder_ty #encoder_where_clause {
-                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -313,12 +312,10 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
                 }
 
                 impl #encoder_impl_generics #private::Buffer for #encoder_ty #encoder_where_clause {
-                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn collect_into(&mut self, #[allow(unused)] out: &mut #private::Vec<u8>) {
                         #collect_into_body
                     }
 
-                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn reserve(&mut self, __additional: ::core::num::NonZeroUsize) {
                         #reserve_body
                     }

--- a/bitcode_derive/src/encode.rs
+++ b/bitcode_derive/src/encode.rs
@@ -284,6 +284,7 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
 
                 // Avoids bounding #impl_generics: Default.
                 impl #encoder_impl_generics ::core::default::Default for #encoder_ty #encoder_where_clause {
+                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn default() -> Self {
                         Self {
                             #default_body
@@ -309,10 +310,12 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
                 }
 
                 impl #encoder_impl_generics #private::Buffer for #encoder_ty #encoder_where_clause {
+                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn collect_into(&mut self, #[allow(unused)] out: &mut #private::Vec<u8>) {
                         #collect_into_body
                     }
 
+                    #[cfg_attr(not(debug_assertions), inline(always))]
                     fn reserve(&mut self, __additional: ::core::num::NonZeroUsize) {
                         #reserve_body
                     }

--- a/bitcode_derive/src/encode.rs
+++ b/bitcode_derive/src/encode.rs
@@ -274,6 +274,9 @@ impl crate::shared::Derive<{ Item::COUNT }> for Encode {
             #[allow(clippy::pedantic)]
             const _: () = {
                 impl #impl_generics #private::Encode for #input_ty #where_clause {
+                    #[cfg(debug_assertions)]
+                    type Encoder = #private::BoxEncoder<#encoder_ty>;
+                    #[cfg(not(debug_assertions))]
                     type Encoder = #encoder_ty;
                 }
 

--- a/src/derive/debug_box.rs
+++ b/src/derive/debug_box.rs
@@ -12,22 +12,26 @@ use core::num::NonZeroUsize;
 pub struct BoxEncoder<E>(Box<E>);
 
 impl<E: Default> Default for BoxEncoder<E> {
+    #[inline(never)]
     fn default() -> Self {
-        Self(Box::new(E::default()))
+        Self(Box::default())
     }
 }
 
 impl<E: Buffer> Buffer for BoxEncoder<E> {
+    #[inline(never)]
     fn collect_into(&mut self, out: &mut Vec<u8>) {
         self.0.collect_into(out);
     }
 
+    #[inline(never)]
     fn reserve(&mut self, additional: NonZeroUsize) {
         self.0.reserve(additional);
     }
 }
 
 impl<T: ?Sized, E: Encoder<T>> Encoder<T> for BoxEncoder<E> {
+    #[inline(never)]
     fn as_primitive(&mut self) -> Option<&mut VecImpl<T>>
     where
         T: Sized,
@@ -35,10 +39,12 @@ impl<T: ?Sized, E: Encoder<T>> Encoder<T> for BoxEncoder<E> {
         self.0.as_primitive()
     }
 
+    #[inline(never)]
     fn encode(&mut self, t: &T) {
         self.0.encode(t);
     }
 
+    #[inline(never)]
     fn encode_vectored<'a>(&mut self, i: impl Iterator<Item = &'a T> + Clone)
     where
         T: 'a,
@@ -51,26 +57,31 @@ impl<T: ?Sized, E: Encoder<T>> Encoder<T> for BoxEncoder<E> {
 pub struct BoxDecoder<D>(Box<D>);
 
 impl<D: Default> Default for BoxDecoder<D> {
+    #[inline(never)]
     fn default() -> Self {
-        Self(Box::new(D::default()))
+        Self(Box::default())
     }
 }
 
 impl<'a, D: View<'a>> View<'a> for BoxDecoder<D> {
+    #[inline(never)]
     fn populate(&mut self, input: &mut &'a [u8], length: usize) -> Result<()> {
         self.0.populate(input, length)
     }
 }
 
 impl<'a, T, D: Decoder<'a, T>> Decoder<'a, T> for BoxDecoder<D> {
+    #[inline(never)]
     fn as_primitive(&mut self) -> Option<&mut SliceImpl<'_, Unaligned<T>>> {
         self.0.as_primitive()
     }
 
+    #[inline(never)]
     fn decode(&mut self) -> T {
         self.0.decode()
     }
 
+    #[inline(never)]
     fn decode_in_place(&mut self, out: &mut MaybeUninit<T>) {
         self.0.decode_in_place(out);
     }

--- a/src/derive/debug_box.rs
+++ b/src/derive/debug_box.rs
@@ -1,0 +1,77 @@
+//! [`Box`] indirection for derived encoders/decoders, used only in debug mode
+//! to avoid stack overflow.
+
+use crate::coder::{Buffer, Decoder, Encoder, Result, View};
+use crate::fast::{SliceImpl, Unaligned, VecImpl};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
+
+/// Wraps a derived [`Encoder`] in a [`Box`] and delegates to it.
+pub struct BoxEncoder<E>(Box<E>);
+
+impl<E: Default> Default for BoxEncoder<E> {
+    fn default() -> Self {
+        Self(Box::new(E::default()))
+    }
+}
+
+impl<E: Buffer> Buffer for BoxEncoder<E> {
+    fn collect_into(&mut self, out: &mut Vec<u8>) {
+        self.0.collect_into(out);
+    }
+
+    fn reserve(&mut self, additional: NonZeroUsize) {
+        self.0.reserve(additional);
+    }
+}
+
+impl<T: ?Sized, E: Encoder<T>> Encoder<T> for BoxEncoder<E> {
+    fn as_primitive(&mut self) -> Option<&mut VecImpl<T>>
+    where
+        T: Sized,
+    {
+        self.0.as_primitive()
+    }
+
+    fn encode(&mut self, t: &T) {
+        self.0.encode(t);
+    }
+
+    fn encode_vectored<'a>(&mut self, i: impl Iterator<Item = &'a T> + Clone)
+    where
+        T: 'a,
+    {
+        self.0.encode_vectored(i);
+    }
+}
+
+/// Wraps a derived [`Decoder`] in a [`Box`] and delegates to it.
+pub struct BoxDecoder<D>(Box<D>);
+
+impl<D: Default> Default for BoxDecoder<D> {
+    fn default() -> Self {
+        Self(Box::new(D::default()))
+    }
+}
+
+impl<'a, D: View<'a>> View<'a> for BoxDecoder<D> {
+    fn populate(&mut self, input: &mut &'a [u8], length: usize) -> Result<()> {
+        self.0.populate(input, length)
+    }
+}
+
+impl<'a, T, D: Decoder<'a, T>> Decoder<'a, T> for BoxDecoder<D> {
+    fn as_primitive(&mut self) -> Option<&mut SliceImpl<'_, Unaligned<T>>> {
+        self.0.as_primitive()
+    }
+
+    fn decode(&mut self) -> T {
+        self.0.decode()
+    }
+
+    fn decode_in_place(&mut self, out: &mut MaybeUninit<T>) {
+        self.0.decode_in_place(out);
+    }
+}

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -7,6 +7,8 @@ use core::num::NonZeroUsize;
 mod array;
 mod atomic;
 pub(crate) mod convert;
+#[cfg(feature = "derive")]
+mod debug_box;
 mod duration;
 mod empty;
 mod impls;
@@ -27,6 +29,7 @@ pub(crate) mod vec;
 pub mod __private {
     extern crate alloc;
     pub use crate::coder::{uninit_field, Buffer, Decoder, Encoder, Result, View};
+    pub use crate::derive::debug_box::{BoxDecoder, BoxEncoder};
     pub use crate::derive::variant::{VariantDecoder, VariantEncoder};
     pub use crate::derive::{Decode, Encode};
     pub fn invalid_enum_variant<T>() -> Result<T> {


### PR DESCRIPTION
Fixes #113 